### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/techouse/qs-kotlin/security/code-scanning/3](https://github.com/techouse/qs-kotlin/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimum required privileges. The best way is to add the block at the workflow root level (before `jobs:`), so it applies to all jobs unless overridden. For most CI workflows that only need to read repository contents (e.g., for checkout, running tests, uploading coverage), `contents: read` is sufficient. If any job needs additional permissions (e.g., to create issues or pull requests), those can be added specifically at the job level. In this case, none of the jobs appear to require write access, so `contents: read` at the root is appropriate.

Edit `.github/workflows/test.yml` by inserting the following block after the workflow `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
