### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     secrets: inherit
+    permissions:
+      contents: read
   publish:
     needs: test
     name: Publish (Maven Central)


### PR DESCRIPTION
Potential fix for [https://github.com/techouse/qs-kotlin/security/code-scanning/4](https://github.com/techouse/qs-kotlin/security/code-scanning/4)

To fix the problem, explicitly set a `permissions` block for the `test` job in `.github/workflows/publish.yml`. This can be done by adding a `permissions` key under the `test` job, similar to how it is set for the `publish` job. The minimal starting point is `contents: read`, which is sufficient for most test jobs that only need to check out code and run tests. This change should be made directly under the `test` job definition (after `uses` and `secrets`), on a new line. No imports or additional definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
