### PR TITLE
:bug: ensure consistent string key usage for maps and correct numeric key handling in `Decoder`

### DIFF
--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Encoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Encoder.kt
@@ -4,20 +4,12 @@ import io.github.techouse.qskotlin.enums.Format
 import io.github.techouse.qskotlin.enums.Formatter
 import io.github.techouse.qskotlin.enums.ListFormat
 import io.github.techouse.qskotlin.enums.ListFormatGenerator
-import io.github.techouse.qskotlin.models.DateSerializer
-import io.github.techouse.qskotlin.models.Filter
-import io.github.techouse.qskotlin.models.FunctionFilter
-import io.github.techouse.qskotlin.models.IterableFilter
-import io.github.techouse.qskotlin.models.Sorter
-import io.github.techouse.qskotlin.models.Undefined
-import io.github.techouse.qskotlin.models.ValueEncoder
-import io.github.techouse.qskotlin.models.WeakWrapper
+import io.github.techouse.qskotlin.models.*
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.LocalDateTime
-import java.util.WeakHashMap
-import kotlin.collections.get
+import java.util.*
 
 /** A helper object for encoding data into a query string format. */
 internal object Encoder {

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Utils.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Utils.kt
@@ -37,18 +37,21 @@ internal object Utils {
                 is Iterable<*> ->
                     when {
                         target.any { it is Undefined } -> {
-                            val mutableTarget: MutableMap<Any, Any?> =
-                                target.withIndex().associate { it.index to it.value }.toMutableMap()
+                            val mutableTarget: MutableMap<String, Any?> =
+                                target
+                                    .withIndex()
+                                    .associate { it.index.toString() to it.value }
+                                    .toMutableMap()
 
                             when (source) {
                                 is Iterable<*> ->
                                     source.forEachIndexed { i, item ->
                                         if (item !is Undefined) {
-                                            mutableTarget[i] = item
+                                            mutableTarget[i.toString()] = item
                                         }
                                     }
 
-                                else -> mutableTarget[mutableTarget.size] = source
+                                else -> mutableTarget[mutableTarget.size.toString()] = source
                             }
 
                             when {
@@ -117,7 +120,7 @@ internal object Utils {
                         is Iterable<*> -> {
                             source.forEachIndexed { i, item ->
                                 if (item !is Undefined) {
-                                    mutableTarget[i] = item
+                                    mutableTarget[i.toString()] = item
                                 }
                             }
                         }
@@ -146,16 +149,16 @@ internal object Utils {
         if (target == null || target !is Map<*, *>) {
             return when (target) {
                 is Iterable<*> -> {
-                    val mutableTarget: MutableMap<Any, Any?> =
+                    val mutableTarget: MutableMap<String, Any?> =
                         target
                             .withIndex()
-                            .associate { it.index to it.value }
+                            .associate { it.index.toString() to it.value }
                             .filterValues { it !is Undefined }
                             .toMutableMap()
 
                     @Suppress("UNCHECKED_CAST")
                     (source as Map<Any, Any?>).forEach { (key, value) ->
-                        mutableTarget[key] = value
+                        mutableTarget[key.toString()] = value
                     }
                     mutableTarget
                 }
@@ -183,10 +186,9 @@ internal object Utils {
                 target is Iterable<*> && source !is Iterable<*> ->
                     target
                         .withIndex()
-                        .associate { it.index to it.value }
+                        .associate { it.index.toString() to it.value }
                         .filterValues { it !is Undefined }
                         .toMutableMap()
-
                 else -> (target as Map<Any, Any?>).toMutableMap()
             }
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/fixtures/data/EmptyTestCases.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/fixtures/data/EmptyTestCases.kt
@@ -178,12 +178,12 @@ internal val EmptyTestCases: List<Map<String, Any>> =
                     "indices" to "[0]=a&[1]=b& [0]=1",
                     "repeat" to "=a&=b& =1",
                 ),
-            "noEmptyKeys" to mapOf(0 to "a", 1 to "b", " " to listOf("1")),
+            "noEmptyKeys" to mapOf("0" to "a", "1" to "b", " " to listOf("1")),
         ),
         mapOf(
             "input" to "[0]=a&[1]=b&a[0]=1&a[1]=2",
             "withEmptyKeys" to mapOf("" to listOf("a", "b"), "a" to listOf("1", "2")),
-            "noEmptyKeys" to mapOf(0 to "a", 1 to "b", "a" to listOf("1", "2")),
+            "noEmptyKeys" to mapOf("0" to "a", "1" to "b", "a" to listOf("1", "2")),
             "stringifyOutput" to
                 mapOf(
                     "brackets" to "[]=a&[]=b&a[]=1&a[]=2",
@@ -207,6 +207,6 @@ internal val EmptyTestCases: List<Map<String, Any>> =
             "withEmptyKeys" to mapOf("" to listOf("a", "b")),
             "stringifyOutput" to
                 mapOf("brackets" to "[]=a&[]=b", "indices" to "[0]=a&[1]=b", "repeat" to "=a&=b"),
-            "noEmptyKeys" to mapOf(0 to "a", 1 to "b"),
+            "noEmptyKeys" to mapOf("0" to "a", "1" to "b"),
         ),
     )

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -74,7 +74,7 @@ class DecodeSpec :
             }
 
             it("parses a simple string") {
-                decode("0=foo") shouldBe mapOf(0 to "foo")
+                decode("0=foo") shouldBe mapOf("0" to "foo")
                 decode("foo=c++") shouldBe mapOf("foo" to "c  ")
                 decode("a[>=]=23") shouldBe mapOf("a" to mapOf(">=" to "23"))
                 decode("a[<=>]==23") shouldBe mapOf("a" to mapOf("<=>" to "=23"))
@@ -304,14 +304,14 @@ class DecodeSpec :
                 decode("a[1]=c&a[0]=b") shouldBe mapOf("a" to listOf("b", "c"))
                 decode("a[1]=c", DecodeOptions(listLimit = 20)) shouldBe mapOf("a" to listOf("c"))
                 decode("a[1]=c", DecodeOptions(listLimit = 0)) shouldBe
-                    mapOf("a" to mapOf(1 to "c"))
+                    mapOf("a" to mapOf("1" to "c"))
                 decode("a[1]=c") shouldBe mapOf("a" to listOf("c"))
                 decode("a[0]=b&a[2]=c", DecodeOptions(parseLists = false)) shouldBe
-                    mapOf("a" to mapOf(0 to "b", 2 to "c"))
+                    mapOf("a" to mapOf("0" to "b", "2" to "c"))
                 decode("a[0]=b&a[2]=c", DecodeOptions(parseLists = true)) shouldBe
                     mapOf("a" to listOf("b", "c"))
                 decode("a[1]=b&a[15]=c", DecodeOptions(parseLists = false)) shouldBe
-                    mapOf("a" to mapOf(1 to "b", 15 to "c"))
+                    mapOf("a" to mapOf("1" to "b", "15" to "c"))
                 decode("a[1]=b&a[15]=c", DecodeOptions(parseLists = true)) shouldBe
                     mapOf("a" to listOf("b", "c"))
             }
@@ -319,10 +319,10 @@ class DecodeSpec :
             it("limits specific list indices to listLimit") {
                 decode("a[20]=a", DecodeOptions(listLimit = 20)) shouldBe mapOf("a" to listOf("a"))
                 decode("a[21]=a", DecodeOptions(listLimit = 20)) shouldBe
-                    mapOf("a" to mapOf(21 to "a"))
+                    mapOf("a" to mapOf("21" to "a"))
 
                 decode("a[20]=a") shouldBe mapOf("a" to listOf("a"))
-                decode("a[21]=a") shouldBe mapOf("a" to mapOf(21 to "a"))
+                decode("a[21]=a") shouldBe mapOf("a" to mapOf("21" to "a"))
             }
 
             it("supports keys that begin with a number") {
@@ -351,15 +351,15 @@ class DecodeSpec :
 
             it("transforms lists to maps") {
                 decode("foo[0]=bar&foo[bad]=baz") shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
                 decode("foo[bad]=baz&foo[0]=bar") shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
                 decode("foo[bad]=baz&foo[]=bar") shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
                 decode("foo[]=bar&foo[bad]=baz") shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
                 decode("foo[bad]=baz&foo[]=bar&foo[]=foo") shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar", 1 to "foo"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar", "1" to "foo"))
                 decode("foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb") shouldBe
                     mapOf(
                         "foo" to
@@ -387,13 +387,13 @@ class DecodeSpec :
                     DecodeOptions(allowDots = true),
                 ) shouldBe mapOf("foo" to listOf(mapOf("baz" to listOf("15", "16"), "bar" to "2")))
                 decode("foo.bad=baz&foo[0]=bar", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
                 decode("foo.bad=baz&foo[]=bar", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
                 decode("foo[]=bar&foo.bad=baz", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
                 decode("foo.bad=baz&foo[]=bar&foo[]=foo", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar", 1 to "foo"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar", "1" to "foo"))
                 decode(
                     "foo[0].a=a&foo[0].b=b&foo[1].a=aa&foo[1].b=bb",
                     DecodeOptions(allowDots = true),
@@ -406,7 +406,7 @@ class DecodeSpec :
 
             it("correctly prunes undefined values when converting a list to a map") {
                 decode("a[2]=b&a[99999999]=c") shouldBe
-                    mapOf("a" to mapOf(2 to "b", 99999999 to "c"))
+                    mapOf("a" to mapOf("2" to "b", "99999999" to "c"))
             }
 
             it("supports malformed uri characters") {
@@ -482,9 +482,9 @@ class DecodeSpec :
             }
 
             it("continues parsing when no parent is found") {
-                decode("[]=&a=b") shouldBe mapOf(0 to "", "a" to "b")
+                decode("[]=&a=b") shouldBe mapOf("0" to "", "a" to "b")
                 decode("[]&a=b", DecodeOptions(strictNullHandling = true)) shouldBe
-                    mapOf(0 to null, "a" to "b")
+                    mapOf("0" to null, "a" to "b")
                 decode("[foo]=bar") shouldBe mapOf("foo" to "bar")
             }
 
@@ -519,25 +519,25 @@ class DecodeSpec :
 
             it("allows overriding list limit") {
                 decode("a[0]=b", DecodeOptions(listLimit = -1)) shouldBe
-                    mapOf("a" to mapOf(0 to "b"))
+                    mapOf("a" to mapOf("0" to "b"))
                 decode("a[0]=b", DecodeOptions(listLimit = 0)) shouldBe mapOf("a" to listOf("b"))
 
                 decode("a[-1]=b", DecodeOptions(listLimit = -1)) shouldBe
-                    mapOf("a" to mapOf(-1 to "b"))
+                    mapOf("a" to mapOf("-1" to "b"))
                 decode("a[-1]=b", DecodeOptions(listLimit = 0)) shouldBe
-                    mapOf("a" to mapOf(-1 to "b"))
+                    mapOf("a" to mapOf("-1" to "b"))
 
                 decode("a[0]=b&a[1]=c", DecodeOptions(listLimit = -1)) shouldBe
-                    mapOf("a" to mapOf(0 to "b", 1 to "c"))
+                    mapOf("a" to mapOf("0" to "b", "1" to "c"))
                 decode("a[0]=b&a[1]=c", DecodeOptions(listLimit = 0)) shouldBe
-                    mapOf("a" to mapOf(0 to "b", 1 to "c"))
+                    mapOf("a" to mapOf("0" to "b", "1" to "c"))
             }
 
             it("allows disabling list parsing") {
                 decode("a[0]=b&a[1]=c", DecodeOptions(parseLists = false)) shouldBe
-                    mapOf("a" to mapOf(0 to "b", 1 to "c"))
+                    mapOf("a" to mapOf("0" to "b", "1" to "c"))
                 decode("a[]=b", DecodeOptions(parseLists = false)) shouldBe
-                    mapOf("a" to mapOf(0 to "b"))
+                    mapOf("a" to mapOf("0" to "b"))
             }
 
             it("allows for query string prefix") {
@@ -725,7 +725,7 @@ class DecodeSpec :
 
                 val expectedList = mutableMapOf<Any, Any?>()
                 expectedList["a"] = mutableMapOf<Any, Any?>()
-                (expectedList["a"] as MutableMap<Any, Any?>)[0] = "b"
+                (expectedList["a"] as MutableMap<Any, Any?>)["0"] = "b"
                 (expectedList["a"] as MutableMap<Any, Any?>)["c"] = "d"
                 decode("a[]=b&a[c]=d") shouldBe expectedList
             }
@@ -1032,7 +1032,17 @@ class DecodeSpec :
                     "a[1]=1&a[2]=2&a[3]=3&a[4]=4&a[5]=5&a[6]=6",
                     DecodeOptions(listLimit = 5),
                 ) shouldBe
-                    mapOf("a" to mapOf(1 to "1", 2 to "2", 3 to "3", 4 to "4", 5 to "5", 6 to "6"))
+                    mapOf(
+                        "a" to
+                            mapOf(
+                                "1" to "1",
+                                "2" to "2",
+                                "3" to "3",
+                                "4" to "4",
+                                "5" to "5",
+                                "6" to "6",
+                            )
+                    )
             }
 
             it("handles list limit of zero correctly") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExampleSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExampleSpec.kt
@@ -179,21 +179,21 @@ class ExampleSpec :
                 }
 
                 it("converts high indices to Map keys") {
-                    decode("a[100]=b") shouldBe mapOf("a" to mapOf(100 to "b"))
+                    decode("a[100]=b") shouldBe mapOf("a" to mapOf("100" to "b"))
                 }
 
                 it("can override list limit") {
                     decode("a[1]=b", DecodeOptions(listLimit = 0)) shouldBe
-                        mapOf("a" to mapOf(1 to "b"))
+                        mapOf("a" to mapOf("1" to "b"))
                 }
 
                 it("can disable list parsing entirely") {
                     decode("a[]=b", DecodeOptions(parseLists = false)) shouldBe
-                        mapOf("a" to mapOf(0 to "b"))
+                        mapOf("a" to mapOf("0" to "b"))
                 }
 
                 it("merges mixed notations into Map") {
-                    decode("a[0]=b&a[b]=c") shouldBe mapOf("a" to mapOf(0 to "b", "b" to "c"))
+                    decode("a[0]=b&a[b]=c") shouldBe mapOf("a" to mapOf("0" to "b", "b" to "c"))
                 }
 
                 it("can create lists of Maps") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
@@ -21,7 +21,7 @@ class QsParserSpec :
                 val options = DecodeOptions()
                 val optionsStrictNullHandling = DecodeOptions(strictNullHandling = true)
 
-                decode("0=foo", options) shouldBe mapOf(0 to "foo")
+                decode("0=foo", options) shouldBe mapOf("0" to "foo")
 
                 decode("foo=c++", options) shouldBe mapOf("foo" to "c  ")
 
@@ -172,7 +172,7 @@ class QsParserSpec :
 
                 decode("a[1]=c", options20) shouldBe mapOf("a" to listOf("c"))
 
-                decode("a[1]=c", options0) shouldBe mapOf("a" to mapOf(1 to "c"))
+                decode("a[1]=c", options0) shouldBe mapOf("a" to mapOf("1" to "c"))
 
                 decode("a[1]=c", options) shouldBe mapOf("a" to listOf("c"))
             }
@@ -183,11 +183,11 @@ class QsParserSpec :
 
                 decode("a[20]=a", options20) shouldBe mapOf("a" to listOf("a"))
 
-                decode("a[21]=a", options20) shouldBe mapOf("a" to mapOf(21 to "a"))
+                decode("a[21]=a", options20) shouldBe mapOf("a" to mapOf("21" to "a"))
 
                 decode("a[20]=a", options) shouldBe mapOf("a" to listOf("a"))
 
-                decode("a[21]=a", options) shouldBe mapOf("a" to mapOf(21 to "a"))
+                decode("a[21]=a", options) shouldBe mapOf("a" to mapOf("21" to "a"))
             }
 
             it("should support keys that begin with a number") {
@@ -231,19 +231,19 @@ class QsParserSpec :
                 val options = DecodeOptions()
 
                 decode("foo[0]=bar&foo[bad]=baz", options) shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
 
                 decode("foo[bad]=baz&foo[0]=bar", options) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
 
                 decode("foo[bad]=baz&foo[]=bar", options) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
 
                 decode("foo[]=bar&foo[bad]=baz", options) shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
 
                 decode("foo[bad]=baz&foo[]=bar&foo[]=foo", options) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar", 1 to "foo"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar", "1" to "foo"))
 
                 decode("foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb", options) shouldBe
                     mapOf(
@@ -277,16 +277,16 @@ class QsParserSpec :
                     mapOf("foo" to listOf(mapOf("baz" to listOf("15", "16"), "bar" to "2")))
 
                 decode("foo.bad=baz&foo[0]=bar", optionsAllowDots) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
 
                 decode("foo.bad=baz&foo[]=bar", optionsAllowDots) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar"))
 
                 decode("foo[]=bar&foo.bad=baz", optionsAllowDots) shouldBe
-                    mapOf("foo" to mapOf(0 to "bar", "bad" to "baz"))
+                    mapOf("foo" to mapOf("0" to "bar", "bad" to "baz"))
 
                 decode("foo.bad=baz&foo[]=bar&foo[]=foo", optionsAllowDots) shouldBe
-                    mapOf("foo" to mapOf("bad" to "baz", 0 to "bar", 1 to "foo"))
+                    mapOf("foo" to mapOf("bad" to "baz", "0" to "bar", "1" to "foo"))
 
                 decode("foo[0].a=a&foo[0].b=b&foo[1].a=aa&foo[1].b=bb", optionsAllowDots) shouldBe
                     mapOf(
@@ -299,7 +299,7 @@ class QsParserSpec :
                 val options = DecodeOptions()
 
                 decode("a[2]=b&a[99999999]=c", options) shouldBe
-                    mapOf("a" to mapOf(2 to "b", 99999999 to "c"))
+                    mapOf("a" to mapOf("2" to "b", "99999999" to "c"))
             }
 
             it("should support malformed URI characters") {
@@ -416,9 +416,9 @@ class QsParserSpec :
                 val options = DecodeOptions()
                 val optionsStrictNullHandling = DecodeOptions(strictNullHandling = true)
 
-                decode("[]=&a=b", options) shouldBe mapOf(0 to "", "a" to "b")
+                decode("[]=&a=b", options) shouldBe mapOf("0" to "", "a" to "b")
 
-                decode("[]&a=b", optionsStrictNullHandling) shouldBe mapOf(0 to null, "a" to "b")
+                decode("[]&a=b", optionsStrictNullHandling) shouldBe mapOf("0" to null, "a" to "b")
 
                 decode("[foo]=bar", optionsStrictNullHandling) shouldBe mapOf("foo" to "bar")
             }
@@ -455,20 +455,21 @@ class QsParserSpec :
             it("should allow overriding list limit") {
                 val optionsNegative = DecodeOptions(listLimit = -1)
 
-                decode("a[0]=b", optionsNegative) shouldBe mapOf("a" to mapOf(0 to "b"))
+                decode("a[0]=b", optionsNegative) shouldBe mapOf("a" to mapOf("0" to "b"))
 
-                decode("a[-1]=b", optionsNegative) shouldBe mapOf("a" to mapOf(-1 to "b"))
+                decode("a[-1]=b", optionsNegative) shouldBe mapOf("a" to mapOf("-1" to "b"))
 
                 decode("a[0]=b&a[1]=c", optionsNegative) shouldBe
-                    mapOf("a" to mapOf(0 to "b", 1 to "c"))
+                    mapOf("a" to mapOf("0" to "b", "1" to "c"))
             }
 
             it("should allow disabling list parsing") {
                 val options = DecodeOptions(parseLists = false)
 
-                decode("a[0]=b&a[1]=c", options) shouldBe mapOf("a" to mapOf(0 to "b", 1 to "c"))
+                decode("a[0]=b&a[1]=c", options) shouldBe
+                    mapOf("a" to mapOf("0" to "b", "1" to "c"))
 
-                decode("a[]=b", options) shouldBe mapOf("a" to mapOf(0 to "b"))
+                decode("a[]=b", options) shouldBe mapOf("a" to mapOf("0" to "b"))
             }
 
             it("should allow for query string prefix") {
@@ -1009,7 +1010,8 @@ class QsParserSpec :
 
                 val expected1 =
                     mapOf(
-                        "foo" to mapOf(0 to "bar", 1 to mapOf("first" to "123"), "second" to "456")
+                        "foo" to
+                            mapOf("0" to "bar", "1" to mapOf("first" to "123"), "second" to "456")
                     )
                 Utils.merge(d1, d2) shouldBe expected1
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
@@ -370,7 +370,7 @@ class UtilsSpec :
         context("Utils.merge") {
             test("merges Map with List") {
                 Utils.merge(mapOf(0 to "a"), listOf(Undefined(), "b")) shouldBe
-                    mapOf(0 to "a", 1 to "b")
+                    mapOf(0 to "a", "1" to "b")
             }
 
             test("merges two objects with the same key and different values") {
@@ -438,7 +438,8 @@ class UtilsSpec :
                     mapOf("foo" to mapOf("second" to "456")),
                 ) shouldBe
                     mapOf(
-                        "foo" to mapOf(0 to "bar", 1 to mapOf("first" to "123"), "second" to "456")
+                        "foo" to
+                            mapOf("0" to "bar", "1" to mapOf("first" to "123"), "second" to "456")
                     )
             }
 
@@ -520,7 +521,7 @@ class UtilsSpec :
                         mapOf("foo" to listOf("bar")),
                         mapOf("foo" to mapOf("baz" to "xyzzy")),
                     )
-                result shouldBe mapOf("foo" to mapOf(0 to "bar", "baz" to "xyzzy"))
+                result shouldBe mapOf("foo" to mapOf("0" to "bar", "baz" to "xyzzy"))
 
                 @Suppress("UNCHECKED_CAST") val map = result as Map<String, Any>
                 map.shouldContainKey("foo")
@@ -533,7 +534,7 @@ class UtilsSpec :
                         mapOf("foo" to mapOf("bar" to "baz")),
                         mapOf("foo" to listOf("xyzzy")),
                     )
-                result shouldBe mapOf("foo" to mapOf("bar" to "baz", 0 to "xyzzy"))
+                result shouldBe mapOf("foo" to mapOf("bar" to "baz", "0" to "xyzzy"))
 
                 @Suppress("UNCHECKED_CAST") val map = result as Map<String, Any>
                 map.shouldContainKey("foo")


### PR DESCRIPTION
This pull request standardizes the handling of map keys throughout the query string decoder and related utilities to always use string keys, even for numeric indices. This change ensures consistency in the decoded output and prevents issues that could arise from mixing integer and string keys in maps. The update also affects test cases and fixtures to align with this new behavior.

**Core decoder and utility logic:**

* Updated `Decoder.kt` and `Utils.kt` to always create maps with string keys instead of integer keys, including for numeric indices and when converting lists to maps. This affects how parsed query strings are represented internally. [[1]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L201-R236) [[2]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L40-R54) [[3]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L120-R123) [[4]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L149-R161) [[5]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L186-L189)

**Test fixtures and cases:**

* Modified all relevant test cases and fixtures in `DecodeSpec.kt`, `ExampleSpec.kt`, `QsParserSpec.kt`, and `EmptyTestCases.kt` so that expected decoded maps use string keys for indices, ensuring tests match the new decoder output. [[1]](diffhunk://#diff-33a27a8a194fd646396d1171b7b9540cf8f2208f0f03489cf0cea6eb57e0c538L181-R186) [[2]](diffhunk://#diff-33a27a8a194fd646396d1171b7b9540cf8f2208f0f03489cf0cea6eb57e0c538L210-R210) [[3]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL77-R77) [[4]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL307-R325) [[5]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL354-R362) [[6]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL390-R396) [[7]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL409-R409) [[8]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL485-R487) [[9]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL522-R540) [[10]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL728-R728) [[11]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL1035-R1045) [[12]](diffhunk://#diff-789da1965172e3c7f80d107f8c57a4fea922d2af2bfc3ca2fac4f7dad0f35e58L182-R196) [[13]](diffhunk://#diff-9fb0cd219a45668e15dcc63c28056f0a755c7ead885ce3fcf142269831be5a07L24-R24)

**Code style and imports:**

* Simplified imports in `Encoder.kt` by using wildcard imports for models and updating standard library imports for consistency.