### PR TITLE
:sparkles: add key-aware decoding to the query string parser

### DIFF
--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/enums/DecodeKind.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/enums/DecodeKind.kt
@@ -1,0 +1,15 @@
+package io.github.techouse.qskotlin.enums
+
+import io.github.techouse.qskotlin.enums.DecodeKind.KEY
+import io.github.techouse.qskotlin.enums.DecodeKind.VALUE
+
+/**
+ * Decoding context for a scalar token.
+ * - [KEY]: the token is a key or key segment. Callers may want to preserve percent-encoded dots
+ *   (%2E / %2e) until after key-splitting.
+ * - [VALUE]: the token is a value; typically fully percent-decode.
+ */
+enum class DecodeKind {
+    KEY,
+    VALUE,
+}

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
@@ -299,16 +299,16 @@ internal object Decoder {
         maxDepth: Int,
         strictDepth: Boolean,
     ): List<String> {
+        // Depth 0 semantics: use the original key as a single segment; never throw.
+        if (maxDepth <= 0) {
+            return listOf(originalKey)
+        }
+
         // Apply dot→bracket *before* splitting, but when depth == 0, we do NOT split at all and do
         // NOT throw.
         val key: String =
             if (allowDots) originalKey.replace(DOT_TO_BRACKET) { "[${it.groupValues[1]}]" }
             else originalKey
-
-        // Depth 0 semantics: use the original key as a single segment; never throw.
-        if (maxDepth <= 0) {
-            return listOf(key)
-        }
 
         val segments = ArrayList<String>(key.count { it == '[' } + 1)
 

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -156,7 +156,8 @@ data class DecodeOptions(
             "Invalid charset"
         }
         require(parameterLimit > 0) { "Parameter limit must be positive" }
-        require(!getDecodeDotInKeys || getAllowDots) {
+        // If decodeDotInKeys is enabled, allowDots must not be explicitly false.
+        require(!getDecodeDotInKeys || allowDots != false) {
             "decodeDotInKeys requires allowDots to be true"
         }
     }
@@ -192,7 +193,8 @@ data class DecodeOptions(
     private fun defaultDecode(value: String?, charset: Charset?, kind: DecodeKind): Any? {
         if (value == null) return null
         if (kind == DecodeKind.KEY) {
-            val protected = protectEncodedDotsForKeys(value, includeOutsideBrackets = getAllowDots)
+            val protected =
+                protectEncodedDotsForKeys(value, includeOutsideBrackets = (allowDots == true))
             return Utils.decode(protected, charset)
         }
         return Utils.decode(value, charset)

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -13,7 +13,8 @@ fun interface Decoder {
 
 /** Back‑compat adapter for `(value, charset) -> Any?` decoders. */
 @Deprecated(
-    message = "Use Decoder fun interface; wrap your two‑arg lambda: Decoder { v, c, _ -> legacy(v, c) }",
+    message =
+        "Use Decoder fun interface; wrap your two‑arg lambda: Decoder { v, c, _ -> legacy(v, c) }",
     replaceWith = ReplaceWith("Decoder { value, charset, _ -> legacyDecoder(value, charset) }"),
     level = DeprecationLevel.WARNING,
 )
@@ -202,9 +203,9 @@ data class DecodeOptions(
      * early.
      *
      * When [includeOutsideBrackets] is true, occurrences both inside and outside bracket segments
-     * are protected. Otherwise, only those **inside** `[...]` are protected.
-     * Note: only literal `[`/`]` affect depth; percent‑encoded brackets (`%5B`/`%5D`) are treated
-     * as content, not structure.
+     * are protected. Otherwise, only those **inside** `[...]` are protected. Note: only literal
+     * `[`/`]` affect depth; percent‑encoded brackets (`%5B`/`%5D`) are treated as content, not
+     * structure.
      */
     private fun protectEncodedDotsForKeys(input: String, includeOutsideBrackets: Boolean): String {
         val pct = input.indexOf('%')

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -217,7 +217,17 @@ data class DecodeOptions(
         return sb.toString()
     }
 
-    /** Back‑compat: decode a value (no kind context). */
+    /**
+     * Back‑compat helper: decode a value without key/value kind context.
+     *
+     * Prefer calling [decode] directly (or [decodeKey]/[decodeValue] for explicit context).
+     */
+    @Deprecated(
+        message = "Use decode(value, charset) or decodeKey/decodeValue for context‑aware decoding.",
+        replaceWith = ReplaceWith("decode(value, charset)"),
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("unused")
     @JvmOverloads
     fun getDecoder(value: String?, charset: Charset? = null): Any? = decode(value, charset)
 

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -205,7 +205,9 @@ data class DecodeOptions(
      * are protected. Otherwise, only those **inside** `[...]` are protected.
      */
     private fun protectEncodedDotsForKeys(input: String, includeOutsideBrackets: Boolean): String {
-        if (input.indexOf('%') < 0) return input
+        val pct = input.indexOf('%')
+        if (pct < 0) return input
+        if (input.indexOf("2E", pct) < 0 && input.indexOf("2e", pct) < 0) return input
         val n = input.length
         val sb = StringBuilder(n + 8)
         var depth = 0
@@ -255,7 +257,8 @@ data class DecodeOptions(
      * Prefer calling [decode] directly (or [decodeKey]/[decodeValue] for explicit context).
      */
     @Deprecated(
-        message = "Use decode(value, charset) or decodeKey/decodeValue for context‑aware decoding.",
+        message =
+            "Deprecated: use decodeKey/decodeValue (or decode(value, charset, kind)) to honor key/value context. This will be removed in the next major.",
         replaceWith = ReplaceWith("decode(value, charset)"),
         level = DeprecationLevel.WARNING,
     )

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -6,7 +6,7 @@ import io.github.techouse.qskotlin.internal.Utils
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
-/** Unified scalar decoder. Implementations may ignore [charset] and/or [kind]. */
+/** Unified scalar decoder. Implementations may ignore `charset` and/or `kind`. */
 fun interface Decoder {
     fun decode(value: String?, charset: Charset?, kind: DecodeKind?): Any?
 }

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -13,7 +13,7 @@ fun interface Decoder {
 
 /** Back‑compat adapter for `(value, charset) -> Any?` decoders. */
 @Deprecated(
-    message = "Use Decoder fun interface; this will be removed in a future major release",
+    message = "Use Decoder fun interface; wrap your two‑arg lambda: Decoder { v, c, _ -> legacy(v, c) }",
     replaceWith = ReplaceWith("Decoder { value, charset, _ -> legacyDecoder(value, charset) }"),
     level = DeprecationLevel.WARNING,
 )
@@ -203,6 +203,8 @@ data class DecodeOptions(
      *
      * When [includeOutsideBrackets] is true, occurrences both inside and outside bracket segments
      * are protected. Otherwise, only those **inside** `[...]` are protected.
+     * Note: only literal `[`/`]` affect depth; percent‑encoded brackets (`%5B`/`%5D`) are treated
+     * as content, not structure.
      */
     private fun protectEncodedDotsForKeys(input: String, includeOutsideBrackets: Boolean): String {
         val pct = input.indexOf('%')
@@ -268,7 +270,7 @@ data class DecodeOptions(
 
     /** Convenience: decode a key to String? */
     internal fun decodeKey(value: String?, charset: Charset?): String? =
-        decode(value, charset, DecodeKind.KEY)?.toString()
+        decode(value, charset, DecodeKind.KEY)?.toString() // keys are always coerced to String
 
     /** Convenience: decode a value */
     internal fun decodeValue(value: String?, charset: Charset?): Any? =

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/EncodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/EncodeOptions.kt
@@ -51,7 +51,12 @@ data class EncodeOptions(
 
     /** The List encoding format to use. */
     private val listFormat: ListFormat? = null,
-    @Deprecated("Use listFormat instead") val indices: Boolean? = null,
+    @Deprecated(
+        message = "Use listFormat instead",
+        replaceWith = ReplaceWith("listFormat"),
+        level = DeprecationLevel.WARNING,
+    )
+    val indices: Boolean? = null,
 
     /** Set to `true` to use dot Map notation in the encoded output. */
     private val allowDots: Boolean? = null,

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -736,7 +736,7 @@ class DecodeSpec :
             it("can parse with custom encoding") {
                 val expected = mapOf("県" to "大阪府")
 
-                val decode: Decoder = Decoder { str, _, _ ->
+                val decode = Decoder { str, _, _ ->
                     str?.replace("%8c%a7", "県")?.replace("%91%e5%8d%e3%95%7b", "大阪府")
                 }
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -1159,5 +1159,21 @@ class DecodeSpec :
                 decode("a.b=c", DecodeOptions(allowDots = true, depth = 0)) shouldBe
                     mapOf("a.b" to "c")
             }
+
+            it("top-level dot→bracket conversion guardrails: leading/trailing/double dots") {
+                // Leading dot: ".a" should yield { "a": ... } when allowDots=true
+                decode(".a=x", DecodeOptions(allowDots = true, decodeDotInKeys = false)) shouldBe
+                    mapOf("a" to "x")
+
+                // Trailing dot: "a." should NOT create an empty bracket segment; remains literal
+                decode("a.=x", DecodeOptions(allowDots = true, decodeDotInKeys = false)) shouldBe
+                    mapOf("a." to "x")
+
+                // Double dots: only the second dot (before a token) causes a split; the empty
+                // middle
+                // segment is preserved as a literal dot in the parent key (no `[]` is created)
+                decode("a..b=x", DecodeOptions(allowDots = true, decodeDotInKeys = false)) shouldBe
+                    mapOf("a." to mapOf("b" to "x"))
+            }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -594,6 +594,8 @@ class DecodeSpec :
                     mapOf("foo" to 1)
                 decode("foo=0", DecodeOptions(comma = true, decoder = decoder)) shouldBe
                     mapOf("foo" to 0)
+                // ensure keys are not coerced to numbers
+                decode("1=foo", DecodeOptions(decoder = decoder)) shouldBe mapOf("1" to "foo")
             }
 
             it(
@@ -1151,6 +1153,11 @@ class DecodeSpec :
                 // allowDots=true & decodeDotInKeys=false → keep %2E inside key segment
                 decode("a%2Eb", DecodeOptions(allowDots = true, decodeDotInKeys = false)) shouldBe
                     mapOf("a%2Eb" to "")
+            }
+
+            it("depth=0 with allowDots=true: do not split key") {
+                decode("a.b=c", DecodeOptions(allowDots = true, depth = 0)) shouldBe
+                    mapOf("a.b" to "c")
             }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -736,11 +736,11 @@ class DecodeSpec :
             it("can parse with custom encoding") {
                 val expected = mapOf("県" to "大阪府")
 
-                val decode = Decoder { str, _, _ ->
+                val customDecoder = Decoder { str, _, _ ->
                     str?.replace("%8c%a7", "県")?.replace("%91%e5%8d%e3%95%7b", "大阪府")
                 }
 
-                decode("%8c%a7=%91%e5%8d%e3%95%7b", DecodeOptions(decoder = decode)) shouldBe
+                decode("%8c%a7=%91%e5%8d%e3%95%7b", DecodeOptions(decoder = customDecoder)) shouldBe
                     expected
             }
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExampleSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExampleSpec.kt
@@ -483,13 +483,14 @@ class ExampleSpec :
                 decode(
                     "%61=%68%65%6c%6c%6f",
                     DecodeOptions(
-                        decoder = { str, _ ->
-                            when (str) {
-                                "%61" -> "a"
-                                "%68%65%6c%6c%6f" -> "hello"
-                                else -> str
+                        decoder =
+                            Decoder { str, _, _ ->
+                                when (str) {
+                                    "%61" -> "a"
+                                    "%68%65%6c%6c%6f" -> "hello"
+                                    else -> str
+                                }
                             }
-                        }
                     ),
                 ) shouldBe mapOf("a" to "hello")
             }

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
@@ -2,6 +2,7 @@ package io.github.techouse.qskotlin.unit
 
 import io.github.techouse.qskotlin.decode
 import io.github.techouse.qskotlin.encode
+import io.github.techouse.qskotlin.enums.DecodeKind
 import io.github.techouse.qskotlin.enums.ListFormat
 import io.github.techouse.qskotlin.internal.Utils
 import io.github.techouse.qskotlin.models.*
@@ -513,11 +514,15 @@ class QsParserSpec :
             }
 
             it("should use number decoder") {
-                val numberDecoder = Decoder { value, _, _ ->
-                    try {
-                        val intValue = value?.toInt()
-                        "[$intValue]"
-                    } catch (_: NumberFormatException) {
+                val numberDecoder = Decoder { value, _, kind ->
+                    if (kind == DecodeKind.VALUE) {
+                        try {
+                            value?.toInt()?.let { "[$it]" } ?: value
+                        } catch (_: NumberFormatException) {
+                            value
+                        }
+                    } else {
+                        // Leave keys untouched
                         value
                     }
                 }
@@ -669,8 +674,9 @@ class QsParserSpec :
 
             it("should allow for decoding keys and values") {
                 val keyValueDecoder: Decoder = Decoder { content: String?, _, _ ->
-                    // Note: Kotlin implementation doesn't distinguish between key and value
-                    // decoding
+                    // This decoder lowercases both keys and values. With DecodeKind available,
+                    // you could branch on kind == DecodeKind.KEY or VALUE if different behaviors
+                    // are desired.
                     content?.lowercase()
                 }
                 val options = DecodeOptions(decoder = keyValueDecoder)

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
@@ -513,7 +513,7 @@ class QsParserSpec :
             }
 
             it("should use number decoder") {
-                val numberDecoder: Decoder = { value, _ ->
+                val numberDecoder = Decoder { value, _, _ ->
                     try {
                         val intValue = value?.toInt()
                         "[$intValue]"
@@ -587,7 +587,7 @@ class QsParserSpec :
             }
 
             it("should parse with custom encoding") {
-                val customDecoder: Decoder = { content, _ ->
+                val customDecoder: Decoder = Decoder { content: String?, _, _ ->
                     try {
                         java.net.URLDecoder.decode(content ?: "", "Shift_JIS")
                     } catch (_: Exception) {
@@ -668,7 +668,7 @@ class QsParserSpec :
             }
 
             it("should allow for decoding keys and values") {
-                val keyValueDecoder: Decoder = { content, _ ->
+                val keyValueDecoder: Decoder = Decoder { content: String?, _, _ ->
                     // Note: Kotlin implementation doesn't distinguish between key and value
                     // decoding
                     content?.lowercase()

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
@@ -592,7 +592,7 @@ class QsParserSpec :
             }
 
             it("should parse with custom encoding") {
-                val customDecoder: Decoder = Decoder { content: String?, _, _ ->
+                val customDecoder = Decoder { content: String?, _, _ ->
                     try {
                         java.net.URLDecoder.decode(content ?: "", "Shift_JIS")
                     } catch (_: Exception) {
@@ -673,7 +673,7 @@ class QsParserSpec :
             }
 
             it("should allow for decoding keys and values") {
-                val keyValueDecoder: Decoder = Decoder { content: String?, _, _ ->
+                val keyValueDecoder = Decoder { content: String?, _, _ ->
                     // This decoder lowercases both keys and values. With DecodeKind available,
                     // you could branch on kind == DecodeKind.KEY or VALUE if different behaviors
                     // are desired.


### PR DESCRIPTION
This pull request refactors and improves the decoding logic in the query string parser, focusing on more robust and context-aware handling of percent-encoded dots in keys and values. The changes introduce a new `DecodeKind` enum to distinguish between key and value decoding, unify the decoder interface, and enhance options for dot handling. The test suite is also updated to cover these behaviors.

**Decoding logic improvements:**

* Added the `DecodeKind` enum to distinguish between key and value decoding contexts, allowing more precise control over how percent-encoded dots are handled.
* Refactored the `Decoder` interface to a unified `fun interface` that accepts value, charset, and kind, supporting more flexible and context-aware decoding.
* Updated `DecodeOptions` with new `decode`, `decodeKey`, and `decodeValue` methods, and improved handling of percent-encoded dots in keys, including case-insensitive replacements and bracket segment logic.

**Core decoder changes:**

* Modified internal decoding logic to use the new context-aware decoding methods, ensuring keys and values are decoded appropriately and percent-encoded dots are handled per the new options. [[1]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L113-R118) [[2]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L127-R129)
* Enhanced bracket segment cleaning and dot decoding to support case-insensitive replacements and stricter rules for dot handling in keys. [[1]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L205-R215) [[2]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L235-R240)

**Test suite updates:**

* Updated all custom decoder usages in tests to use the new `Decoder` interface, ensuring compatibility with the refactored decoding logic. [[1]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL588-R589) [[2]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL736-R737) [[3]](diffhunk://#diff-6888fe93c1e990608accd72b3033ccc02edac8052e208d49ace849c7b86db0cbL827-R828) [[4]](diffhunk://#diff-789da1965172e3c7f80d107f8c57a4fea922d2af2bfc3ca2fac4f7dad0f35e58L486-R487) [[5]](diffhunk://#diff-9fb0cd219a45668e15dcc63c28056f0a755c7ead885ce3fcf142269831be5a07L516-R516) [[6]](diffhunk://#diff-9fb0cd219a45668e15dcc63c28056f0a755c7ead885ce3fcf142269831be5a07L590-R590) [[7]](diffhunk://#diff-9fb0cd219a45668e15dcc63c28056f0a755c7ead885ce3fcf142269831be5a07L671-R671)
* Added comprehensive tests for encoded dot behavior in keys, covering various combinations of `allowDots` and `decodeDotInKeys` options, bracket segments, and case sensitivity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Kind-aware decoding added (keys vs values) and a new decoder interface to handle them, plus convenience decoding helpers.

- **Bug Fixes**
  - Preserves encoded dots in keys (case-insensitive) and improves bracket/root and top-level dot parsing to avoid incorrect key splitting.

- **Deprecations**
  - Legacy two-argument decoder deprecated with a migration path to the new decoder interface.

- **Tests**
  - Expanded tests covering encoded-dot/key-value behaviors and updated to the new decoder API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->