### PR TITLE
:white_check_mark: add more tests

### DIFF
--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/EncodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/EncodeSpec.kt
@@ -20,7 +20,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import java.util.Locale
+import java.util.*
 
 class EncodeSpec :
     DescribeSpec({
@@ -112,7 +112,7 @@ class EncodeSpec :
                             EncodeOptions(
                                 encode = false,
                                 filter =
-                                    FunctionFilter { prefix: String, map: Any? ->
+                                    FunctionFilter { _: String, map: Any? ->
                                         // This should trigger the code path that accesses
                                         // properties of non-Map, non-Iterable objects
                                         val result = mutableMapOf<String, Any?>()
@@ -1184,7 +1184,7 @@ class EncodeSpec :
 
                         value is LocalDateTime -> {
                             prefix shouldBe "e[f]"
-                            value.atZone(java.time.ZoneOffset.UTC).toInstant().toEpochMilli()
+                            value.atZone(ZoneOffset.UTC).toInstant().toEpochMilli()
                         }
 
                         else -> value
@@ -2014,7 +2014,7 @@ class EncodeSpec :
 
             it("FunctionFilter branch inside recursion (prefix non-empty)") {
                 var count = 0
-                val filter = FunctionFilter { prefix, value ->
+                val filter = FunctionFilter { _, value ->
                     count += 1
                     // When prefix not empty return value unchanged; at root return original map
                     value

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/SentinelSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/SentinelSpec.kt
@@ -1,0 +1,13 @@
+package io.github.techouse.qskotlin.unit
+
+import io.github.techouse.qskotlin.enums.Sentinel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SentinelSpec :
+    FunSpec({
+        test("sentinel encoded values are exposed") {
+            Sentinel.ISO.asQueryParam() shouldBe Sentinel.ISO.toString()
+            Sentinel.CHARSET.toEntry().key shouldBe Sentinel.PARAM_NAME
+        }
+    })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
@@ -1,0 +1,47 @@
+package io.github.techouse.qskotlin.unit.internal
+
+import io.github.techouse.qskotlin.internal.Decoder
+import io.github.techouse.qskotlin.models.DecodeOptions
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.nio.charset.StandardCharsets
+
+class DecoderInternalSpec :
+    DescribeSpec({
+        describe("Decoder.parseQueryStringValues") {
+            it("rejects non-positive parameter limits") {
+                shouldThrow<IllegalArgumentException> {
+                    Decoder.parseQueryStringValues("a=1", DecodeOptions(parameterLimit = 0))
+                }
+            }
+
+            it("throws when parameter limit exceeded and throwOnLimitExceeded=true") {
+                val options = DecodeOptions(parameterLimit = 1, throwOnLimitExceeded = true)
+                shouldThrow<IndexOutOfBoundsException> {
+                    Decoder.parseQueryStringValues("a=1&b=2", options)
+                }
+            }
+
+            it("splits comma-delimited lists respecting limits") {
+                val options = DecodeOptions(comma = true)
+                val result = Decoder.parseQueryStringValues("list=a,b", options)
+                result["list"] shouldBe listOf("a", "b")
+            }
+
+            it("respects charset sentinel and numeric entities") {
+                val options =
+                    DecodeOptions(
+                        interpretNumericEntities = true,
+                        charset = StandardCharsets.ISO_8859_1,
+                        charsetSentinel = true,
+                        ignoreQueryPrefix = true,
+                    )
+
+                val result =
+                    Decoder.parseQueryStringValues("?utf8=%26%2310003%3B&name=%26%2365%3B", options)
+                result.containsKey("name") shouldBe true
+                result["name"] shouldBe "A"
+            }
+        }
+    })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/EncoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/EncoderInternalSpec.kt
@@ -1,0 +1,61 @@
+package io.github.techouse.qskotlin.unit.internal
+
+import io.github.techouse.qskotlin.enums.Format
+import io.github.techouse.qskotlin.enums.ListFormat
+import io.github.techouse.qskotlin.internal.Encoder
+import io.github.techouse.qskotlin.models.IterableFilter
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.nio.charset.StandardCharsets
+
+class EncoderInternalSpec :
+    DescribeSpec({
+        describe("Encoder.encode internals") {
+            it("applies defaults when optional parameters are null") {
+                val calls = mutableListOf<String>()
+                val result =
+                    Encoder.encode(
+                        data = listOf("v1"),
+                        undefined = false,
+                        sideChannel = mutableMapOf(),
+                        prefix = null,
+                        generateArrayPrefix = null,
+                        commaRoundTrip = null,
+                        encoder = { value, _, _ ->
+                            val text = value?.toString() ?: "<null>"
+                            calls += text
+                            "enc:$text"
+                        },
+                        format = Format.RFC3986,
+                        formatter = Format.RFC3986.formatter,
+                        charset = StandardCharsets.UTF_8,
+                        addQueryPrefix = true,
+                    )
+
+                result.shouldBeInstanceOf<List<*>>()
+                result shouldBe listOf("enc:?[0]=enc:v1")
+                calls shouldBe listOf("?[0]", "v1")
+            }
+
+            it("ignores out-of-range array indices exposed by IterableFilter") {
+                val result =
+                    Encoder.encode(
+                        data = listOf("only"),
+                        undefined = false,
+                        sideChannel = mutableMapOf(),
+                        prefix = "arr",
+                        generateArrayPrefix = ListFormat.INDICES.generator,
+                        filter = IterableFilter(listOf(2)),
+                        encoder = { value, _, _ -> value?.toString() ?: "" },
+                        format = Format.RFC3986,
+                        formatter = Format.RFC3986.formatter,
+                        charset = StandardCharsets.UTF_8,
+                    )
+
+                result.shouldBeInstanceOf<List<*>>()
+                result.shouldBeEmpty()
+            }
+        }
+    })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/EncoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/EncoderInternalSpec.kt
@@ -5,19 +5,20 @@ import io.github.techouse.qskotlin.enums.ListFormat
 import io.github.techouse.qskotlin.internal.Encoder
 import io.github.techouse.qskotlin.models.IterableFilter
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
 
 class EncoderInternalSpec :
     DescribeSpec({
         describe("Encoder.encode internals") {
             it("applies defaults when optional parameters are null") {
                 val calls = mutableListOf<String>()
+                val data = arrayOf("v1")
                 val result =
                     Encoder.encode(
-                        data = listOf("v1"),
+                        data = data,
                         undefined = false,
                         sideChannel = mutableMapOf(),
                         prefix = null,
@@ -34,15 +35,16 @@ class EncoderInternalSpec :
                         addQueryPrefix = true,
                     )
 
-                result.shouldBeInstanceOf<List<*>>()
-                result shouldBe listOf("enc:?[0]=enc:v1")
-                calls shouldBe listOf("?[0]", "v1")
+                result.shouldBeInstanceOf<String>()
+                result shouldBe "enc:?=enc:${data.toString()}"
+                calls shouldBe listOf("?", data.toString())
             }
 
             it("ignores out-of-range array indices exposed by IterableFilter") {
+                val data = arrayOf("only")
                 val result =
                     Encoder.encode(
-                        data = listOf("only"),
+                        data = data,
                         undefined = false,
                         sideChannel = mutableMapOf(),
                         prefix = "arr",
@@ -54,8 +56,27 @@ class EncoderInternalSpec :
                         charset = StandardCharsets.UTF_8,
                     )
 
-                result.shouldBeInstanceOf<List<*>>()
-                result.shouldBeEmpty()
+                result.shouldBeInstanceOf<String>()
+                result shouldBe "arr=${data.toString()}"
+            }
+
+            it("serializes LocalDateTime values with custom serializer") {
+                val stamp = LocalDateTime.parse("2024-05-01T10:15:00")
+                val result =
+                    Encoder.encode(
+                        data = stamp,
+                        undefined = false,
+                        sideChannel = mutableMapOf(),
+                        prefix = "ts",
+                        serializeDate = { dt -> "X${dt.toLocalDate()}" },
+                        encoder = { value, _, _ -> value?.toString() ?: "" },
+                        format = Format.RFC3986,
+                        formatter = Format.RFC3986.formatter,
+                        charset = StandardCharsets.UTF_8,
+                    )
+
+                result.shouldBeInstanceOf<String>()
+                result shouldBe "ts=X2024-05-01"
             }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
@@ -195,6 +195,12 @@ class DecodeOptionsSpec :
                 opts.decode("%2E", StandardCharsets.UTF_8, DecodeKind.VALUE) shouldBe "."
             }
 
+            it("decodeKey/decodeValue return null when input null") {
+                val opts = DecodeOptions()
+                opts.decodeKey(null) shouldBe null
+                opts.decodeValue(null) shouldBe null
+            }
+
             it("Decoder is used for KEY and for VALUE") {
                 val calls = mutableListOf<Pair<String?, DecodeKind>>()
                 val opts =

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
@@ -4,16 +4,13 @@ package io.github.techouse.qskotlin.unit.models
 
 import io.github.techouse.qskotlin.enums.DecodeKind
 import io.github.techouse.qskotlin.enums.Duplicates
-import io.github.techouse.qskotlin.models.DecodeOptions
-import io.github.techouse.qskotlin.models.Decoder
-import io.github.techouse.qskotlin.models.Delimiter
-import io.github.techouse.qskotlin.models.JDecoder
-import io.github.techouse.qskotlin.models.JLegacyDecoder
-import io.github.techouse.qskotlin.models.LegacyDecoder
-import io.github.techouse.qskotlin.models.RegexDelimiter
+import io.github.techouse.qskotlin.internal.Utils
+import io.github.techouse.qskotlin.models.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
@@ -340,6 +337,31 @@ class DecodeOptionsSpec :
             it("defaults exposes baseline instance") {
                 DecodeOptions.defaults() shouldBe DecodeOptions()
                 DecodeOptions.builder().build() shouldBe DecodeOptions()
+            }
+
+            it("java-friendly aliases mirror computed flags") {
+                val implied = DecodeOptions(decodeDotInKeys = true)
+                implied.isAllowDotsEffective() shouldBe true
+                implied.isDecodeDotInKeysEffective() shouldBe true
+
+                val explicit = DecodeOptions(allowDots = false)
+                explicit.isAllowDotsEffective() shouldBe false
+                explicit.isDecodeDotInKeysEffective() shouldBe false
+            }
+
+            it("decode uses defaults when charset and kind omitted") {
+                val opts = DecodeOptions()
+                opts.decode("a%20b") shouldBe Utils.decode("a%20b")
+                opts.decodeKey("foo%20bar") shouldBe "foo bar"
+                opts.decodeValue("foo%20bar") shouldBe "foo bar"
+            }
+
+            it("rejects unsupported charset") {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        DecodeOptions(charset = Charset.forName("US-ASCII"))
+                    }
+                error.message.shouldContain("Invalid charset")
             }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
@@ -8,7 +8,6 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.util.regex.Pattern
-import kotlin.text.RegexOption
 
 class DelimiterSpec :
     DescribeSpec({

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
@@ -1,0 +1,57 @@
+package io.github.techouse.qskotlin.unit.models
+
+import io.github.techouse.qskotlin.models.Delimiter
+import io.github.techouse.qskotlin.models.RegexDelimiter
+import io.github.techouse.qskotlin.models.StringDelimiter
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.regex.Pattern
+import kotlin.text.RegexOption
+
+class DelimiterSpec :
+    DescribeSpec({
+        describe("Delimiter factories") {
+            it("string factory splits using literal separator") {
+                val d = Delimiter.string("&")
+                d.shouldBeInstanceOf<StringDelimiter>().value shouldBe "&"
+                d.split("a=b&c=d&").filter { it.isNotEmpty() } shouldBe listOf("a=b", "c=d")
+            }
+
+            it("regex factories preserve patterns and flags") {
+                val compiled = Pattern.compile("[;&]", Pattern.CASE_INSENSITIVE)
+                val fromPattern = Delimiter.regex(compiled)
+                val fromString = Delimiter.regex("[;&]")
+                val fromFlags = Delimiter.regex("[;&]", Pattern.CASE_INSENSITIVE)
+                val fromOptions = Delimiter.regex("[;&]", setOf(RegexOption.DOT_MATCHES_ALL))
+
+                fromPattern.shouldBeInstanceOf<RegexDelimiter>().apply {
+                    val source = this.pattern
+                    source.contains(';') shouldBe true
+                    source.contains('&') shouldBe true
+                    flags shouldBe Pattern.CASE_INSENSITIVE
+                }
+                fromString.shouldBeInstanceOf<RegexDelimiter>().apply {
+                    val source = this.pattern
+                    source.contains(';') shouldBe true
+                    source.contains('&') shouldBe true
+                    flags shouldBe 0
+                }
+                fromFlags.shouldBeInstanceOf<RegexDelimiter>().flags shouldBe
+                    Pattern.CASE_INSENSITIVE
+                fromOptions.shouldBeInstanceOf<RegexDelimiter>().flags shouldBe
+                    RegexOption.DOT_MATCHES_ALL.value
+
+                fromFlags.split("a=b;c=d").filter { it.isNotEmpty() } shouldBe listOf("a=b", "c=d")
+            }
+
+            it("predefined delimiters use literal separators") {
+                Delimiter.AMPERSAND.split("a=b&c=d").filter { it.isNotEmpty() } shouldBe
+                    listOf("a=b", "c=d")
+                Delimiter.COMMA.split("a=b,c=d").filter { it.isNotEmpty() } shouldBe
+                    listOf("a=b", "c=d")
+                Delimiter.SEMICOLON.split("a=b;c=d").filter { it.isNotEmpty() } shouldBe
+                    listOf("a=b", "c=d")
+            }
+        }
+    })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
@@ -196,6 +196,12 @@ class EncodeOptionsSpec :
                     "D:2024-12-31"
             }
 
+            it("exposes deprecated indices property for compatibility") {
+                val options = EncodeOptions(indices = true)
+                @Suppress("DEPRECATION")
+                options.indices shouldBe true
+            }
+
             it("builder accepts kotlin lambdas for encoder and date serializer") {
                 val options =
                     EncodeOptions.builder()

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
@@ -2,12 +2,7 @@ package io.github.techouse.qskotlin.unit.models
 
 import io.github.techouse.qskotlin.enums.Format
 import io.github.techouse.qskotlin.enums.ListFormat
-import io.github.techouse.qskotlin.models.Delimiter
-import io.github.techouse.qskotlin.models.EncodeOptions
-import io.github.techouse.qskotlin.models.FunctionFilter
-import io.github.techouse.qskotlin.models.JDateSerializer
-import io.github.techouse.qskotlin.models.JValueEncoder
-import io.github.techouse.qskotlin.models.StringDelimiter
+import io.github.techouse.qskotlin.models.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
This pull request adds comprehensive new unit tests for the core encoding and decoding utilities in the `qs-kotlin` project, focusing on improved coverage for edge cases, option handling, and custom behaviors. The new and expanded tests ensure that the `Utils`, `Decoder`, and `Encoder` internals, as well as the `DecodeOptions` model, behave correctly under a wide range of scenarios, including error handling, option defaults, and custom configuration.

**New and expanded utility tests:**

* Added tests to `UtilsSpec` for encoding/decoding fallbacks, compacting nested structures with cycle detection, merging custom iterables and maps, list trimming, numeric entity decoding, and primitive/empty checks. Also introduced a `BoxIterable` helper for custom iterable testing. [[1]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR133-R136) [[2]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR202-R205) [[3]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR214-R232) [[4]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR399-R434) [[5]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR651-R670) [[6]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR737-R740) [[7]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR785-R799)

* Added a new `SentinelSpec` to test the exposure of encoded values and parameter names for the `Sentinel` enum.

**Internal encoder/decoder testing:**

* Added `DecoderInternalSpec` with tests for parameter limits, comma-delimited list parsing, charset sentinels, and numeric entity interpretation within query string parsing.
* Added `EncoderInternalSpec` with tests for default parameter application, array index filtering, and custom serialization (e.g., for `LocalDateTime`).

**DecodeOptions model coverage:**

* Expanded `DecodeOptionsSpec` to test null input handling, builder wiring for Kotlin/Java overloads, validation of all configuration options, default exposure, and charset validation. [[1]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89L7-R15) [[2]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89R198-R203) [[3]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89R285-R372)

These changes significantly improve the reliability and maintainability of the codebase by ensuring that all edge cases and configuration combinations are thoroughly tested.

**References:**  
[[1]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR133-R136) [[2]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR202-R205) [[3]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR214-R232) [[4]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR399-R434) [[5]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR651-R670) [[6]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR737-R740) [[7]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR785-R799) [[8]](diffhunk://#diff-26dfb87bcb71da23844445720a2d7e2f0ae1d72748982d54a4c7fde7a2ea693eR1-R13) [[9]](diffhunk://#diff-8199bb2a0c3b6437ef6d58f61f82d464d85c1614acb25dcd7456b0384a3be0a7R1-R47) [[10]](diffhunk://#diff-18a656e7e3555ad27a419c5b3a8f5d03eb3601d4468ee0903e08889b2afcd1b8R1-R82) [[11]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89L7-R15) [[12]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89R198-R203) [[13]](diffhunk://#diff-6b4cbabf6710388d1492026f3b179d7c39910038283fc424ef806b64328e8d89R285-R372)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive unit tests for encoder/decoder behavior, utilities, and model options (encode/decode/delimiter).
  - Covered edge cases: charset handling, numeric entities, parameter limits, comma-delimited lists, list parsing, null handling, empty values, surrogate pairs, merging/compaction logic, and date serialization.
  - Introduced tests for enum query param encoding and delimiter factories (string and regex), including flag validation and error conditions.

- Style
  - Simplified imports, standardized unused parameter naming in lambdas, and aligned references to existing constants for clarity in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->