### PR TITLE
:white_check_mark: increase unit test coverage

### DIFF
--- a/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/DelimiterInteropTest.java
+++ b/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/DelimiterInteropTest.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import kotlin.text.RegexOption;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -153,5 +154,12 @@ public class DelimiterInteropTest {
     String ts = ciUnicode.toString();
     assertTrue(ts.contains("abc"));
     assertTrue(ts.contains(String.valueOf(ciUnicode.getFlags())));
+  }
+
+  @Test
+  @DisplayName("regex(pattern, Set<RegexOption>) factory works for Java callers")
+  void regexFactoryWithKotlinOptions() {
+    RegexDelimiter fromOptions = Delimiter.regex("[,&]", java.util.Set.of(RegexOption.IGNORE_CASE));
+    assertTrue((fromOptions.getFlags() & Pattern.CASE_INSENSITIVE) != 0);
   }
 }

--- a/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/ExtensionsInteropTest.java
+++ b/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/ExtensionsInteropTest.java
@@ -38,4 +38,9 @@ final class ExtensionsInteropTest {
       assertEquals(tc.getEncoded(), qs, "encode mismatch for: " + input);
     }
   }
+
+  @Test
+  void map_toQueryString_uses_default_overload() {
+    assertEquals("a=b", QS.toQueryString(Map.of("a", "b")));
+  }
 }

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExtensionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExtensionsSpec.kt
@@ -24,5 +24,9 @@ class ExtensionsSpec :
                         testCase.encoded
                 }
             }
+
+            test("uses default EncodeOptions overload when omitted") {
+                mapOf("a" to "b").toQueryString() shouldBe "a=b"
+            }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/SentinelSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/SentinelSpec.kt
@@ -8,6 +8,8 @@ class SentinelSpec :
     FunSpec({
         test("sentinel encoded values are exposed") {
             Sentinel.ISO.asQueryParam() shouldBe Sentinel.ISO.toString()
+            Sentinel.ISO.encoded shouldBe "utf8=%26%2310003%3B"
             Sentinel.CHARSET.toEntry().key shouldBe Sentinel.PARAM_NAME
+            Sentinel.CHARSET.encoded shouldBe "utf8=%E2%9C%93"
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
@@ -209,6 +209,12 @@ class UtilsSpec :
                 Utils.decode("name%2Eobj%2Efoo", StandardCharsets.ISO_8859_1) shouldBe
                     "name.obj.foo"
             }
+
+            test("returns input unchanged when URLDecoder cannot parse UTF-8 sequence") {
+                Utils.decode("%E0%") shouldBe "%E0%"
+            }
+
+            test("handles null input safely") { Utils.decode(null) shouldBe null }
         }
 
         context("Utils.compact") {
@@ -227,6 +233,13 @@ class UtilsSpec :
 
                 val compacted = Utils.compact(root, allowSparseLists = true)
                 compacted["self"].shouldBeInstanceOf<MutableList<*>>()
+            }
+
+            test("default allowSparseLists removes undefined entries") {
+                val list = mutableListOf<Any?>(Undefined(), "ok")
+                val root: MutableMap<String, Any?> = mutableMapOf("items" to list)
+
+                Utils.compact(root)["items"] shouldBe mutableListOf("ok")
             }
         }
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
@@ -43,5 +43,27 @@ class DecoderInternalSpec :
                 result.containsKey("name") shouldBe true
                 result["name"] shouldBe "A"
             }
+
+            it("uses default options overload when omitted") {
+                Decoder.parseQueryStringValues("foo=bar") shouldBe mutableMapOf("foo" to "bar")
+            }
+        }
+
+        describe("Decoder.parseKeys") {
+            it("handles nested list chains while respecting parent indices") {
+                val options = DecodeOptions(parseLists = true)
+                val value = listOf(listOf("x", "y"))
+
+                @Suppress("UNCHECKED_CAST")
+                val parsed =
+                    Decoder.parseKeys(
+                        givenKey = "0[]",
+                        value = value,
+                        options = options,
+                        valuesParsed = true,
+                    ) as Map<String, Any?>
+
+                parsed["0"] shouldBe listOf(listOf("x", "y"))
+            }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
@@ -1,7 +1,9 @@
 package io.github.techouse.qskotlin.unit.internal
 
+import io.github.techouse.qskotlin.enums.Duplicates
 import io.github.techouse.qskotlin.internal.Decoder
 import io.github.techouse.qskotlin.models.DecodeOptions
+import io.github.techouse.qskotlin.models.Undefined
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -47,6 +49,27 @@ class DecoderInternalSpec :
             it("uses default options overload when omitted") {
                 Decoder.parseQueryStringValues("foo=bar") shouldBe mutableMapOf("foo" to "bar")
             }
+
+            it("decodes bare keys honoring strictNullHandling") {
+                val result =
+                    Decoder.parseQueryStringValues("flag", DecodeOptions(strictNullHandling = true))
+
+                result shouldBe mutableMapOf<String, Any?>("flag" to null)
+            }
+
+            it("wraps bracket suffix comma values as nested lists") {
+                val options = DecodeOptions(comma = true)
+                val result = Decoder.parseQueryStringValues("tags[]=a,b", options)
+
+                result["tags[]"] shouldBe listOf(listOf("a", "b"))
+            }
+
+            it("combines duplicate keys when duplicates=COMBINE") {
+                val options = DecodeOptions(duplicates = Duplicates.COMBINE)
+                val result = Decoder.parseQueryStringValues("k=1&k=2", options)
+
+                result["k"] shouldBe listOf("1", "2")
+            }
         }
 
         describe("Decoder.parseKeys") {
@@ -64,6 +87,65 @@ class DecoderInternalSpec :
                     ) as Map<String, Any?>
 
                 parsed["0"] shouldBe listOf(listOf("x", "y"))
+            }
+
+            it("produces empty list when allowEmptyLists consumes blank value") {
+                val options =
+                    DecodeOptions(
+                        parseLists = true,
+                        allowEmptyLists = true,
+                        strictNullHandling = false,
+                    )
+
+                val parsed =
+                    Decoder.parseKeys(
+                        givenKey = "list[]",
+                        value = "",
+                        options = options,
+                        valuesParsed = true,
+                    ) as Map<*, *>
+
+                parsed["list"] shouldBe mutableListOf<Any?>()
+            }
+
+            it("falls back to map entries when parseLists disabled") {
+                val options = DecodeOptions(parseLists = false)
+
+                val parsed =
+                    Decoder.parseKeys(
+                        givenKey = "arr[3]",
+                        value = "v",
+                        options = options,
+                        valuesParsed = true,
+                    ) as Map<*, *>
+
+                parsed["arr"] shouldBe mapOf("3" to "v")
+            }
+
+            it("enforces listLimit for nested list growth") {
+                val options = DecodeOptions(listLimit = 1, throwOnLimitExceeded = true)
+                val nested = listOf(listOf("a", "b"))
+
+                shouldThrow<IndexOutOfBoundsException> {
+                    Decoder.parseKeys(
+                        givenKey = "0[]",
+                        value = nested,
+                        options = options,
+                        valuesParsed = false,
+                    )
+                }
+            }
+
+            it("creates indexed lists for bracketed numeric keys within limit") {
+                val parsed =
+                    Decoder.parseKeys(
+                        givenKey = "items[2]",
+                        value = "x",
+                        options = DecodeOptions(),
+                        valuesParsed = true,
+                    ) as Map<*, *>
+
+                parsed["items"] shouldBe mutableListOf(Undefined(), Undefined(), "x")
             }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
@@ -107,6 +107,14 @@ class DecodeOptionsSpec :
                 newOptions.parseLists shouldBe true
                 newOptions.strictNullHandling shouldBe false
             }
+
+            it("rejects negative depth at construction time") {
+                shouldThrow<IllegalArgumentException> { DecodeOptions(depth = -1) }
+            }
+
+            it("exposes defaults() convenience instance") {
+                DecodeOptions.defaults() shouldBe DecodeOptions()
+            }
         }
 
         val charsets = listOf(StandardCharsets.UTF_8, StandardCharsets.ISO_8859_1)

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DelimiterSpec.kt
@@ -50,6 +50,9 @@ class DelimiterSpec :
                 }
                 fromEmptyOptions.shouldBeInstanceOf<RegexDelimiter>().flags shouldBe 0
 
+                Delimiter.regex(pattern = "[;&]", options = setOf(RegexOption.LITERAL))
+                    .shouldBeInstanceOf<RegexDelimiter>()
+
                 fromFlags.split("a=b;c=d").filter { it.isNotEmpty() } shouldBe listOf("a=b", "c=d")
             }
 

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
@@ -210,10 +210,6 @@ class EncodeOptionsSpec :
                     "d-2020-05-01"
             }
 
-            it("provides defaults() factory for Java callers") {
-                EncodeOptions.defaults() shouldBe EncodeOptions()
-            }
-
             it("rejects unsupported charsets") {
                 val error =
                     shouldThrow<IllegalArgumentException> {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/EncodeOptionsSpec.kt
@@ -210,6 +210,10 @@ class EncodeOptionsSpec :
                     "d-2020-05-01"
             }
 
+            it("provides defaults() factory for Java callers") {
+                EncodeOptions.defaults() shouldBe EncodeOptions()
+            }
+
             it("rejects unsupported charsets") {
                 val error =
                     shouldThrow<IllegalArgumentException> {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/WeakWrapperSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/WeakWrapperSpec.kt
@@ -62,6 +62,19 @@ class WeakWrapperSpec :
                 w1 shouldNotBe Any()
             }
 
+            it("equals short-circuits when other referent already cleared") {
+                val referent = Any()
+                val w1 = WeakWrapper(referent)
+                val w2 = WeakWrapper(referent)
+                val field =
+                    WeakWrapper::class.java.getDeclaredField("weakRef").apply {
+                        isAccessible = true
+                    }
+                field.set(w2, WeakReference<Any?>(null))
+
+                (w1 == w2) shouldBe false
+            }
+
             it("Inequality: different referents") {
                 val w1 = WeakWrapper(Any())
                 val w2 = WeakWrapper(Any())


### PR DESCRIPTION
This pull request adds comprehensive new unit tests and test cases across multiple modules to improve coverage and verify correct behavior for edge cases, defaults, and error handling in the Kotlin query string library. The changes include tests for decoders, encoders, delimiters, utility functions, and models, ensuring robustness and correct handling of special scenarios.

**Decoder and Encoder Improvements:**
- Added tests to `DecoderInternalSpec` for default options, handling of bare keys, nested lists, duplicate keys, and list limits, as well as for `parseKeys` logic with various options.
- Added tests to `EncoderInternalSpec` for handling empty lists, serializing temporal types, propagating undefined flags, and detecting cyclic references.

**Utility and Model Enhancements:**
- Added tests to `UtilsSpec` for decoding malformed UTF-8, handling null input, and compacting lists with undefined entries. [[1]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR212-R217) [[2]](diffhunk://#diff-5badbec62a19fc37ed3b20a615e3f972a48ec7a34e2cac3a8f47d79f1e64370fR237-R243)
- Added a test to `DecodeOptionsSpec` to reject negative depth and expose a `defaults()` convenience method.
- Added a test to `WeakWrapperSpec` to verify equality logic when the referent is cleared.

**Delimiter and Query String Interop:**
- Added tests in `DelimiterSpec` and `DelimiterInteropTest` for regex delimiters with Kotlin options and literal options. [[1]](diffhunk://#diff-62d1eda38e0c2e9cd86277f4567033e4c7f3eb1619ef1917d6de93d216eea83aR53-R55) [[2]](diffhunk://#diff-96e051ed4439cce263fb56016b24e0096728fc1b72688258b603ffd72cfa7d6eR158-R164)
- Added tests in `ExtensionsInteropTest` and `ExtensionsSpec` to verify default overloads for `toQueryString`. [[1]](diffhunk://#diff-82081a47c3fdd852d926c7156d3e9271b4b2fe78385fd5211a23bda100f9be37R41-R45) [[2]](diffhunk://#diff-dc5149df173eb546bb2530b96830d3a10b8e8866173675e10a8692a331f75a5cR27-R30)

**Sentinel and Miscellaneous:**
- Added assertions in `SentinelSpec` to verify encoded values for sentinels.

**Dependency and Import Updates:**
- Added necessary imports for new test cases, including `RegexOption`, `Duplicates`, `Undefined`, and temporal types. [[1]](diffhunk://#diff-96e051ed4439cce263fb56016b24e0096728fc1b72688258b603ffd72cfa7d6eR15) [[2]](diffhunk://#diff-8199bb2a0c3b6437ef6d58f61f82d464d85c1614acb25dcd7456b0384a3be0a7R3-R6) [[3]](diffhunk://#diff-18a656e7e3555ad27a419c5b3a8f5d03eb3601d4468ee0903e08889b2afcd1b8R7-R12)

These changes significantly improve the reliability and maintainability of the codebase by ensuring correct behavior across a wide range of scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Java-friendly overload to create regex-based delimiters using a set of Kotlin RegexOptions.
  - Introduced defaults() factory methods to quickly obtain default EncodeOptions and DecodeOptions from Java or Kotlin.
- Tests
  - Expanded coverage for encoding/decoding edge cases, delimiter options, interop paths, and internal parser/encoder behaviors, including cyclic detection and list handling.
  - Added validations for option constructors and equality semantics in utility models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->