### PR TITLE
:sparkles: align behavior more closely with `qs` version 6.15.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* [FEAT] add `DecodeOptions.strictMerge` and default object/scalar conflicts to list wrapping to match `qs` 6.15.0
+* [FEAT] add `DecodeOptions.strictMerge` and default object/scalar conflicts to list wrapping to match `qs` 6.15.x
 * [FIX] match `qs` 6.15.x duplicate bracket-list handling, list-limit overflow semantics, depth-zero dot normalization, and comma overflow preservation
 * [FIX] apply RFC formatters to strict-null encoded keys
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* [FEAT] add `DecodeOptions.strictMerge` and default object/scalar conflicts to list wrapping to match `qs` 6.15.0
+* [FIX] match `qs` 6.15.x duplicate bracket-list handling, list-limit overflow semantics, depth-zero dot normalization, and comma overflow preservation
+* [FIX] apply RFC formatters to strict-null encoded keys
+
 ## 1.5.7
 
 * [CHORE] add WPT-derived form URL encoding fixture coverage for encode/decode parity, including resource-backed fixture loading and provenance checks

--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ QS.decode(
   DecodeOptions(duplicates = Duplicates.LAST)
 )
 // => mapOf("foo" to "baz")
+
+QS.decode(
+  "foo=bar&foo=baz&items[]=a&items[]=b",
+  DecodeOptions(duplicates = Duplicates.LAST)
+)
+// => mapOf("foo" to "baz", "items" to listOf("a", "b"))
 ```
 Java:
 ```java
@@ -416,6 +422,47 @@ QS.decode(
     .build()
 );
 // => {foo=baz}
+
+QS.decode(
+  "foo=bar&foo=baz&items[]=a&items[]=b",
+  DecodeOptions.builder()
+    .duplicates(Duplicates.LAST)
+    .build()
+);
+// => {foo=baz, items=[a, b]}
+```
+
+Bracket-list notation (`[]`) always combines values, regardless of
+`duplicates`.
+
+### Strict merge
+
+When a key appears as both an object and a scalar, qs-kotlin wraps the conflict
+in a list by default:
+
+Kotlin:
+```kotlin
+QS.decode("a[b]=c&a=d")
+// => mapOf("a" to listOf(mapOf("b" to "c"), "d"))
+
+QS.decode(
+  "a[b]=c&a=d",
+  DecodeOptions(strictMerge = false)
+)
+// => mapOf("a" to mapOf("b" to "c", "d" to true))
+```
+Java:
+```java
+QS.decode("a[b]=c&a=d");
+// => {a=[{b=c}, d]}
+
+QS.decode(
+  "a[b]=c&a=d",
+  DecodeOptions.builder()
+    .strictMerge(false)
+    .build()
+);
+// => {a={b=c, d=true}}
 ```
 
 ### Charset and sentinel
@@ -533,12 +580,13 @@ QS.decode("a[]=&a[]=b");
 // => {a=["", b]}
 ```
 
-Large indices convert to a map by default:
+`listLimit` is the maximum list element count. Indices greater than or equal to
+the limit convert to a map by default:
 
 Kotlin:
 ```kotlin
 QS.decode("a[100]=b")
-// => mapOf("a" to mapOf(100 to "b"))
+// => mapOf("a" to mapOf("100" to "b"))
 ```
 Java:
 ```java
@@ -554,7 +602,7 @@ QS.decode(
   "a[]=b",
   DecodeOptions(parseLists = false)
 )
-// => mapOf("a" to mapOf(0 to "b"))
+// => mapOf("a" to mapOf("0" to "b"))
 ```
 Java:
 ```java
@@ -572,7 +620,7 @@ Mixing notations merges into a map:
 Kotlin:
 ```kotlin
 QS.decode("a[0]=b&a[b]=c")
-// => mapOf("a" to mapOf(0 to "b", "b" to "c"))
+// => mapOf("a" to mapOf("0" to "b", "b" to "c"))
 ```
 Java:
 ```java
@@ -601,10 +649,9 @@ QS.decode(
 // => {a=[b, c]}
 ```
 
-When `comma = true`, this port enforces `listLimit` for comma-split values. If
-`throwOnLimitExceeded = true`, decode throws; otherwise values are truncated to the
-configured `listLimit`. This intentionally differs from `qs@6.14.2`, which converts
-over-limit comma results to an object-like overflow structure.
+When `comma = true`, comma-split values also honor `listLimit`. If
+`throwOnLimitExceeded = true`, decode throws; otherwise over-limit comma results
+convert to a map while preserving all values.
 
 ### Primitive/scalar values
 

--- a/comparison/js/package.json
+++ b/comparison/js/package.json
@@ -6,6 +6,6 @@
   "license": "BSD-3-Clause",
   "packageManager": "pnpm@11.1.3",
   "dependencies": {
-    "qs": "^6.15.1"
+    "qs": "^6.15.2"
   }
 }

--- a/comparison/js/pnpm-lock.yaml
+++ b/comparison/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       qs:
-        specifier: ^6.15.1
-        version: 6.15.1
+        specifier: ^6.15.2
+        version: 6.15.2
 
 packages:
 
@@ -69,8 +69,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.1.tgz}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.2.tgz}
     engines: {node: '>=0.6'}
 
   side-channel-list@1.0.1:
@@ -147,7 +147,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
@@ -23,36 +23,31 @@ internal object Decoder {
      * @param currentListLength The current length of the list being parsed, used for limit checks.
      * @return The parsed value, which may be a List or the original value if no parsing is needed.
      */
-    private fun parseListValue(value: Any?, options: DecodeOptions, currentListLength: Int): Any? {
+    private fun parseListValue(
+        value: Any?,
+        options: DecodeOptions,
+        currentListLength: Int,
+        isBracketListValue: Boolean = false,
+    ): Any? {
         if (value is String && value.isNotEmpty() && options.comma && value.contains(',')) {
-            if (options.listLimit >= 0) {
-                val remaining = options.listLimit - currentListLength
-                if (options.throwOnLimitExceeded) {
-                    if (remaining < 0) {
-                        throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
-                    }
-                    val splitVal =
-                        if (remaining == Int.MAX_VALUE) {
-                            splitCommaValue(value)
-                        } else {
-                            splitCommaValue(value, remaining + 1)
-                        }
-                    if (splitVal.size > remaining) {
-                        throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
-                    }
-                    return splitVal
+            if (options.throwOnLimitExceeded && !isBracketListValue) {
+                if (options.listLimit < 0) {
+                    throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
                 }
-                if (remaining <= 0) return emptyList<String>()
-                return splitCommaValue(value, remaining)
+                val splitVal =
+                    splitCommaValue(
+                        value,
+                        if (options.listLimit == Int.MAX_VALUE) null else options.listLimit + 1,
+                    )
+                if (splitVal.size > options.listLimit) {
+                    throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
+                }
+                return splitVal
             }
             return splitCommaValue(value)
         }
 
-        if (
-            options.listLimit >= 0 &&
-                options.throwOnLimitExceeded &&
-                currentListLength >= options.listLimit
-        ) {
+        if (options.throwOnLimitExceeded && currentListLength >= options.listLimit) {
             throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
         }
 
@@ -211,11 +206,13 @@ internal object Decoder {
 
             val part = parts[i]
             if (part.isEmpty()) continue
+            val isBracketListValue = part.contains("[]=")
             val bracketEqualsPos = part.indexOf("]=")
             val pos = if (bracketEqualsPos == -1) part.indexOf('=') else bracketEqualsPos + 1
 
             val key: String
             var value: Any?
+            var parsedCommaList = false
 
             if (pos == -1) {
                 // Decode a bare key (no '=') using key-aware decoding
@@ -224,16 +221,19 @@ internal object Decoder {
             } else {
                 // Decode the key slice as a key; values decode as values
                 key = options.decodeKey(part.take(pos), charset).orEmpty()
+                val rawValue = part.substring(pos + 1)
+                val parsedValue =
+                    parseListValue(
+                        rawValue,
+                        options,
+                        if (obj.containsKey(key) && obj[key] is List<*>) {
+                            (obj[key] as List<*>).size
+                        } else 0,
+                        isBracketListValue,
+                    )
+                parsedCommaList = rawValue.isNotEmpty() && options.comma && rawValue.contains(',')
                 value =
-                    Utils.apply(
-                        parseListValue(
-                            part.substring(pos + 1),
-                            options,
-                            if (obj.containsKey(key) && obj[key] is List<*>) {
-                                (obj[key] as List<*>).size
-                            } else 0,
-                        )
-                    ) { v: Any? ->
+                    Utils.apply(parsedValue) { v: Any? ->
                         options.decodeValue(v as String?, charset)
                     }
             }
@@ -252,13 +252,20 @@ internal object Decoder {
                     )
             }
 
-            if (part.contains("[]=")) {
+            if (isBracketListValue) {
                 value = if (value is Iterable<*>) listOf(value) else value
+            }
+
+            if (parsedCommaList && value is List<*> && value.size > options.listLimit) {
+                if (options.throwOnLimitExceeded) {
+                    throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
+                }
+                value = Utils.combine(emptyList<Any?>(), value, options.listLimit)
             }
 
             val existing = obj.containsKey(key)
             when {
-                existing && options.duplicates == Duplicates.COMBINE -> {
+                existing && (options.duplicates == Duplicates.COMBINE || isBracketListValue) -> {
                     obj[key] = Utils.combine(obj[key], value, options.listLimit)
                 }
 
@@ -330,19 +337,29 @@ internal object Decoder {
                     idx != null && root != decodedRoot && idx.toString() == decodedRoot
 
                 when {
-                    // If list parsing is disabled OR listLimit < 0: always make a map with string
-                    // key
-                    !options.parseLists || options.listLimit < 0 -> {
+                    // If list parsing is disabled, always make a map with string key.
+                    !options.parseLists -> {
                         val keyForMap = if (decodedRoot == "") "0" else decodedRoot
                         mutableObj[keyForMap] = leaf
                         obj = mutableObj
                     }
 
-                    // Proper list index (e.g., "[3]") and allowed by listLimit -> build a list
-                    isBracketedNumeric && idx >= 0 && idx <= options.listLimit -> {
+                    // Proper list index (e.g., "[3]") and allowed by listLimit -> build a list.
+                    isBracketedNumeric && idx >= 0 && idx < options.listLimit -> {
                         val list = MutableList<Any?>(idx + 1) { Undefined.Companion() }
                         list[idx] = leaf
                         obj = list
+                    }
+
+                    isBracketedNumeric && idx >= 0 && options.throwOnLimitExceeded -> {
+                        throw IndexOutOfBoundsException(listLimitExceededMessage(options.listLimit))
+                    }
+
+                    isBracketedNumeric && idx >= 0 -> {
+                        val overflow = Utils.OverflowMap()
+                        overflow[decodedRoot] = leaf
+                        overflow.maxIndex = idx
+                        obj = overflow
                     }
 
                     // Otherwise, treat it as a map with *string* key (even if numeric)
@@ -489,14 +506,12 @@ internal object Decoder {
         maxDepth: Int,
         strictDepth: Boolean,
     ): List<String> {
-        // Depth 0 semantics: use the original key as a single segment; never throw.
-        if (maxDepth <= 0) {
-            return listOf(originalKey)
-        }
-
-        // Apply dot→bracket *before* splitting, but when depth == 0, we do NOT split at all and do
-        // NOT throw.
         val key: String = if (allowDots) dotToBracketTopLevel(originalKey) else originalKey
+
+        // Depth 0 semantics: normalize dots first, then keep the key as a single segment.
+        if (maxDepth <= 0) {
+            return listOf(key)
+        }
 
         val segments = ArrayList<String>(key.count { it == '[' } + 1)
 

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
@@ -58,24 +58,6 @@ internal object Decoder {
         return "List limit exceeded. Only $limit element${if (limit == 1) "" else "s"} allowed in a list."
     }
 
-    private fun findKeyValueSeparator(part: String): Int {
-        var firstEquals = -1
-        var depth = 0
-
-        for (i in part.indices) {
-            when (part[i]) {
-                '[' -> depth += 1
-                ']' -> if (depth > 0) depth -= 1
-                '=' -> {
-                    if (firstEquals == -1) firstEquals = i
-                    if (depth == 0) return i
-                }
-            }
-        }
-
-        return firstEquals
-    }
-
     private fun splitCommaValue(value: String, maxParts: Int? = null): List<String> {
         if (maxParts != null && maxParts <= 0) return emptyList()
 
@@ -224,7 +206,8 @@ internal object Decoder {
 
             val part = parts[i]
             if (part.isEmpty()) continue
-            val pos = findKeyValueSeparator(part)
+            val bracketEqualsPos = part.indexOf("]=")
+            val pos = if (bracketEqualsPos == -1) part.indexOf('=') else bracketEqualsPos + 1
             val keySlice = if (pos == -1) part else part.take(pos)
             val isBracketListValue = keySlice.endsWith("[]")
 

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Decoder.kt
@@ -58,6 +58,24 @@ internal object Decoder {
         return "List limit exceeded. Only $limit element${if (limit == 1) "" else "s"} allowed in a list."
     }
 
+    private fun findKeyValueSeparator(part: String): Int {
+        var firstEquals = -1
+        var depth = 0
+
+        for (i in part.indices) {
+            when (part[i]) {
+                '[' -> depth += 1
+                ']' -> if (depth > 0) depth -= 1
+                '=' -> {
+                    if (firstEquals == -1) firstEquals = i
+                    if (depth == 0) return i
+                }
+            }
+        }
+
+        return firstEquals
+    }
+
     private fun splitCommaValue(value: String, maxParts: Int? = null): List<String> {
         if (maxParts != null && maxParts <= 0) return emptyList()
 
@@ -206,9 +224,9 @@ internal object Decoder {
 
             val part = parts[i]
             if (part.isEmpty()) continue
-            val isBracketListValue = part.contains("[]=")
-            val bracketEqualsPos = part.indexOf("]=")
-            val pos = if (bracketEqualsPos == -1) part.indexOf('=') else bracketEqualsPos + 1
+            val pos = findKeyValueSeparator(part)
+            val keySlice = if (pos == -1) part else part.take(pos)
+            val isBracketListValue = keySlice.endsWith("[]")
 
             val key: String
             var value: Any?
@@ -216,11 +234,11 @@ internal object Decoder {
 
             if (pos == -1) {
                 // Decode a bare key (no '=') using key-aware decoding
-                key = options.decodeKey(part, charset).orEmpty()
+                key = options.decodeKey(keySlice, charset).orEmpty()
                 value = if (options.strictNullHandling) null else ""
             } else {
                 // Decode the key slice as a key; values decode as values
-                key = options.decodeKey(part.take(pos), charset).orEmpty()
+                key = options.decodeKey(keySlice, charset).orEmpty()
                 val rawValue = part.substring(pos + 1)
                 val parsedValue =
                     parseListValue(

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Encoder.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Encoder.kt
@@ -231,7 +231,7 @@ internal object Encoder {
                                 } else {
                                     materializedPath()
                                 }
-                            finishFrame(keyOnly)
+                            finishFrame(context.formatter(keyOnly))
                             continue
                         }
                         obj = ""
@@ -563,7 +563,7 @@ internal object Encoder {
                     } else {
                         path.materialize()
                     }
-                return listOf(keyOnly)
+                return listOf(context.formatter(keyOnly))
             }
             leaf = ""
         }

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Utils.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/internal/Utils.kt
@@ -38,6 +38,21 @@ internal object Utils {
         var overflowMax: Int? = null,
     )
 
+    private fun isFalsyPrimitiveForMerge(value: Any?): Boolean =
+        when (value) {
+            null -> true
+            is Undefined -> true
+            is String -> value.isEmpty()
+            is Boolean -> !value
+            is Byte -> value.toInt() == 0
+            is Short -> value.toInt() == 0
+            is Int -> value == 0
+            is Long -> value == 0L
+            is Float -> value == 0f || value.isNaN()
+            is Double -> value == 0.0 || value.isNaN()
+            else -> false
+        }
+
     /**
      * Merges two objects, where the source object overrides or extends the target object.
      * - If the source is a Map, it will merge its entries into the target.
@@ -92,7 +107,7 @@ internal object Utils {
                     val currentTarget = frame.target
                     val currentSource = frame.source
 
-                    if (currentSource == null) {
+                    if (isFalsyPrimitiveForMerge(currentSource)) {
                         stack.removeLast()
                         frame.onResult(currentTarget)
                         continue
@@ -196,6 +211,16 @@ internal object Utils {
                                     frame.onResult(currentTarget)
                                     continue
                                 }
+                                if (
+                                    frame.options.strictMerge &&
+                                        currentSource !is Iterable<*> &&
+                                        currentSource !is Undefined &&
+                                        !isFalsyPrimitiveForMerge(currentSource)
+                                ) {
+                                    stack.removeLast()
+                                    frame.onResult(listOf(currentTarget, currentSource))
+                                    continue
+                                }
                                 val mutableTarget = currentTarget.toMutableMap()
 
                                 when (currentSource) {
@@ -210,8 +235,8 @@ internal object Utils {
                                         // ignore
                                     }
                                     else -> {
-                                        val k = currentSource.toString()
-                                        if (k.isNotEmpty()) {
+                                        if (!isFalsyPrimitiveForMerge(currentSource)) {
+                                            val k = currentSource.toString()
                                             mutableTarget[k] = true
                                         }
                                     }
@@ -869,7 +894,7 @@ internal object Utils {
             else -> result.add(b)
         }
 
-        if (limit >= 0 && result.size > limit) {
+        if (result.size > limit) {
             val map = OverflowMap()
             result.forEachIndexed { index, item -> map[index.toString()] = item }
             map.maxIndex = result.size - 1

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/models/DecodeOptions.kt
@@ -67,11 +67,11 @@ data class DecodeOptions(
     val allowSparseLists: Boolean = false,
 
     /**
-     * QS will limit specifying indices in a List to a maximum index of `20`. Any List members with
-     * an index of greater than `20` will instead be converted to a Map with the index as the key.
-     * This is needed to handle cases when someone sent, for example, `a[999999999]` and it will
-     * take significant time to iterate over this huge List. This limit can be overridden by passing
-     * a listLimit option.
+     * QS will limit parsed List values to a maximum count of `20`. Any explicit index greater than
+     * or equal to the limit is converted to a Map with the index as the key. This is needed to
+     * handle cases when someone sent, for example, `a[999999999]` and it would take significant
+     * time to iterate over this huge List. This limit can be overridden by passing a listLimit
+     * option.
      */
     val listLimit: Int = 20,
 
@@ -145,6 +145,15 @@ data class DecodeOptions(
 
     /** Set to `true` to throw an error when the limit is exceeded. */
     val throwOnLimitExceeded: Boolean = false,
+
+    /**
+     * Preserve object/scalar conflicts as lists.
+     *
+     * When `true`, `a[b]=c&a=d` decodes as `a = [{ b = c }, d]`, matching modern qs behavior. Set
+     * to `false` to restore legacy behavior where the scalar is added as a map key with value
+     * `true`.
+     */
+    val strictMerge: Boolean = true,
 ) {
     /**
      * Builder for [DecodeOptions]. Prefer this from Java to avoid long, ambiguous constructors.
@@ -180,6 +189,7 @@ data class DecodeOptions(
         private var interpretNumericEntities: Boolean = false
         private var parseLists: Boolean = true
         private var strictDepth: Boolean = false
+        private var strictMerge: Boolean = true
         private var strictNullHandling: Boolean = false
         private var throwOnLimitExceeded: Boolean = false
 
@@ -228,8 +238,8 @@ data class DecodeOptions(
         fun allowSparseLists(value: Boolean) = apply { this.allowSparseLists = value }
 
         /**
-         * Maximum explicit index allowed when parsing lists. Higher indices trigger a map fallback
-         * to avoid huge sparse allocations. Default is 20.
+         * Maximum list element count. Indices greater than or equal to this value trigger a map
+         * fallback to avoid huge sparse allocations. Default is 20.
          */
         fun listLimit(value: Int) = apply { this.listLimit = value }
 
@@ -288,6 +298,12 @@ data class DecodeOptions(
          */
         fun strictDepth(value: Boolean) = apply { this.strictDepth = value }
 
+        /**
+         * When `true`, object/scalar merge conflicts are wrapped in lists. Set to `false` for
+         * legacy qs behavior.
+         */
+        fun strictMerge(value: Boolean) = apply { this.strictMerge = value }
+
         /** When `true`, parameters without `=` decode to `null` (rather than empty string). */
         fun strictNullHandling(value: Boolean) = apply { this.strictNullHandling = value }
 
@@ -315,6 +331,7 @@ data class DecodeOptions(
                 interpretNumericEntities = interpretNumericEntities,
                 parseLists = parseLists,
                 strictDepth = strictDepth,
+                strictMerge = strictMerge,
                 strictNullHandling = strictNullHandling,
                 throwOnLimitExceeded = throwOnLimitExceeded,
             )

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -159,18 +159,30 @@ class DecodeSpec :
                     .message shouldBe "List limit exceeded. Only 3 elements allowed in a list."
             }
 
-            it("comma: true truncates when list limit exceeded without throwing") {
+            it("comma: true converts to a map when list limit exceeded without throwing") {
                 decode(
                     "a=b,c",
                     DecodeOptions(comma = true, throwOnLimitExceeded = false, listLimit = 1),
-                ) shouldBe mapOf("a" to listOf("b"))
+                ) shouldBe mapOf("a" to mapOf("0" to "b", "1" to "c"))
             }
 
-            it("comma: true ignores negative list limit") {
+            it("comma: true applies list limit after bracket list wrapping") {
+                decode(
+                    "a[]=b,c,d",
+                    DecodeOptions(comma = true, throwOnLimitExceeded = true, listLimit = 1),
+                ) shouldBe mapOf("a" to listOf(listOf("b", "c", "d")))
+
+                decode(
+                    "a[]=b,c,d",
+                    DecodeOptions(comma = true, throwOnLimitExceeded = false, listLimit = 0),
+                ) shouldBe mapOf("a" to mapOf("0" to listOf("b", "c", "d")))
+            }
+
+            it("comma: true treats negative list limit as exceeded") {
                 decode(
                     "a=b,c",
                     DecodeOptions(comma = true, throwOnLimitExceeded = false, listLimit = -1),
-                ) shouldBe mapOf("a" to listOf("b", "c"))
+                ) shouldBe mapOf("a" to mapOf("0" to "b", "1" to "c"))
             }
 
             it("comma: true counts existing list length across duplicates") {
@@ -182,11 +194,11 @@ class DecodeSpec :
                 }
             }
 
-            it("comma: true keeps existing list when duplicate arrives at list limit") {
+            it("comma: true preserves duplicate comma values as a map when over list limit") {
                 decode(
                     "a=b,c&a=d,e",
                     DecodeOptions(comma = true, throwOnLimitExceeded = false, listLimit = 2),
-                ) shouldBe mapOf("a" to listOf("b", "c"))
+                ) shouldBe mapOf("a" to mapOf("0" to "b", "1" to "c", "2" to "d", "3" to "e"))
             }
 
             it("allows enabling dot notation") {
@@ -318,11 +330,13 @@ class DecodeSpec :
                     mapOf("a" to mapOf("b" to mapOf("[c][d]" to "e")))
             }
 
-            it("uses original key when depth = 0") {
+            it("normalizes dots before keeping a single key when depth = 0") {
                 decode("a[0]=b&a[1]=c", DecodeOptions(depth = 0)) shouldBe
                     mapOf("a[0]" to "b", "a[1]" to "c")
                 decode("a[0][0]=b&a[0][1]=c&a[1]=d&e=2", DecodeOptions(depth = 0)) shouldBe
                     mapOf("a[0][0]" to "b", "a[0][1]" to "c", "a[1]" to "d", "e" to "2")
+                decode("a.b=c", DecodeOptions(depth = 0, allowDots = true)) shouldBe
+                    mapOf("a[b]" to "c")
             }
 
             it("parses a simple list") { decode("a=b&a=c") shouldBe mapOf("a" to listOf("b", "c")) }
@@ -345,7 +359,12 @@ class DecodeSpec :
                 decode(".a=x&a=y", DecodeOptions(allowDots = true)) shouldBe
                     mapOf("a" to listOf("x", "y"))
                 decode(".a[b]=x&a=y", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("a" to mapOf("b" to "x", "y" to true))
+                    mapOf("a" to listOf(mapOf("b" to "x"), "y"))
+
+                decode("a[]=b&a=") shouldBe mapOf("a" to listOf("b"))
+                decode("a[0]=b&a=") shouldBe mapOf("a" to listOf("b"))
+                decode("a[20]=b&a=") shouldBe mapOf("a" to mapOf("20" to "b"))
+                decode("a[b]=c&a=") shouldBe mapOf("a" to mapOf("b" to "c"))
 
                 decode("a[1]=b&a=c", DecodeOptions(listLimit = 20)) shouldBe
                     mapOf("a" to listOf("b", "c"))
@@ -387,12 +406,12 @@ class DecodeSpec :
             }
 
             it("limits specific list indices to listLimit") {
-                decode("a[20]=a", DecodeOptions(listLimit = 20)) shouldBe mapOf("a" to listOf("a"))
-                decode("a[21]=a", DecodeOptions(listLimit = 20)) shouldBe
-                    mapOf("a" to mapOf("21" to "a"))
+                decode("a[19]=a", DecodeOptions(listLimit = 20)) shouldBe mapOf("a" to listOf("a"))
+                decode("a[20]=a", DecodeOptions(listLimit = 20)) shouldBe
+                    mapOf("a" to mapOf("20" to "a"))
 
-                decode("a[20]=a") shouldBe mapOf("a" to listOf("a"))
-                decode("a[21]=a") shouldBe mapOf("a" to mapOf("21" to "a"))
+                decode("a[19]=a") shouldBe mapOf("a" to listOf("a"))
+                decode("a[20]=a") shouldBe mapOf("a" to mapOf("20" to "a"))
             }
 
             it("supports keys that begin with a number") {
@@ -590,7 +609,8 @@ class DecodeSpec :
             it("allows overriding list limit") {
                 decode("a[0]=b", DecodeOptions(listLimit = -1)) shouldBe
                     mapOf("a" to mapOf("0" to "b"))
-                decode("a[0]=b", DecodeOptions(listLimit = 0)) shouldBe mapOf("a" to listOf("b"))
+                decode("a[0]=b", DecodeOptions(listLimit = 0)) shouldBe
+                    mapOf("a" to mapOf("0" to "b"))
 
                 decode("a[-1]=b", DecodeOptions(listLimit = -1)) shouldBe
                     mapOf("a" to mapOf("-1" to "b"))
@@ -787,6 +807,37 @@ class DecodeSpec :
 
             it("add keys to maps") { decode("a[b]=c") shouldBe mapOf("a" to mapOf("b" to "c")) }
 
+            it("parses literal bracket text inside bracket groups") {
+                decode("search[withbracket[]]=foobar") shouldBe
+                    mapOf("search" to mapOf("withbracket[]" to "foobar"))
+                decode("a[b[]]=c") shouldBe mapOf("a" to mapOf("b[]" to "c"))
+                decode("list[][x[]]=y") shouldBe mapOf("list" to listOf(mapOf("x[]" to "y")))
+                decode("a[b[c[]]]=d") shouldBe mapOf("a" to mapOf("b[c[]]" to "d"))
+                decode("a[b[c[]]][d]=e", DecodeOptions(depth = 1)) shouldBe
+                    mapOf("a" to mapOf("b[c[]]" to mapOf("[d]" to "e")))
+                decode("a[[]b=c") shouldBe mapOf("a" to mapOf("[[]b" to "c"))
+            }
+
+            it("does not mangle percent-encoded bracket text") {
+                decode("a%25255Bb=c") shouldBe mapOf("a%255Bb" to "c")
+                decode("a%25255Db=c") shouldBe mapOf("a%255Db" to "c")
+                decode("a%5Bb%25255Bc%5D=d") shouldBe mapOf("a" to mapOf("b%255Bc" to "d"))
+            }
+
+            it("strictMerge wraps object and scalar conflicts by default") {
+                decode("a[b]=c&a=d") shouldBe mapOf("a" to listOf(mapOf("b" to "c"), "d"))
+                decode("a=d&a[b]=c") shouldBe mapOf("a" to listOf("d", mapOf("b" to "c")))
+                decode("a[b]=c&a=toString") shouldBe
+                    mapOf("a" to listOf(mapOf("b" to "c"), "toString"))
+            }
+
+            it("strictMerge=false restores legacy object scalar merge behavior") {
+                decode("a[b]=c&a=d", DecodeOptions(strictMerge = false)) shouldBe
+                    mapOf("a" to mapOf("b" to "c", "d" to true))
+                decode("a[b]=c&a=", DecodeOptions(strictMerge = false)) shouldBe
+                    mapOf("a" to mapOf("b" to "c"))
+            }
+
             @Suppress("UNCHECKED_CAST")
             it("can return null maps") {
                 val expected = mutableMapOf<String, Any?>()
@@ -813,6 +864,16 @@ class DecodeSpec :
 
                 decode("%8c%a7=%91%e5%8d%e3%95%7b", DecodeOptions(decoder = customDecoder)) shouldBe
                     expected
+            }
+
+            it("ignores keys when the custom decoder returns null for a key") {
+                val decoder = Decoder { str, charset, kind ->
+                    if (kind == DecodeKind.KEY && str == "drop") null
+                    else Utils.decode(str, charset)
+                }
+
+                decode("drop=value&keep=value", DecodeOptions(decoder = decoder)) shouldBe
+                    mapOf("keep" to "value")
             }
 
             it("parses an iso-8859-1 string if asked to") {
@@ -973,11 +1034,11 @@ class DecodeSpec :
                     mapOf("foo" to listOf("bar", "baz"))
             }
 
-            it("duplicates: combine with listLimit < 0 preserves list") {
+            it("duplicates: combine with listLimit < 0 converts to map") {
                 decode(
                     "foo=bar&foo=baz",
                     DecodeOptions(duplicates = Duplicates.COMBINE, listLimit = -1),
-                ) shouldBe mapOf("foo" to listOf("bar", "baz"))
+                ) shouldBe mapOf("foo" to mapOf("0" to "bar", "1" to "baz"))
             }
 
             it("duplicates: first") {
@@ -988,6 +1049,14 @@ class DecodeSpec :
             it("duplicates: last") {
                 decode("foo=bar&foo=baz", DecodeOptions(duplicates = Duplicates.LAST)) shouldBe
                     mapOf("foo" to "baz")
+            }
+
+            it("bracket notation always combines regardless of duplicates") {
+                decode("a=1&a=2&b[]=1&b[]=2", DecodeOptions(duplicates = Duplicates.FIRST)) shouldBe
+                    mapOf("a" to "1", "b" to listOf("1", "2"))
+
+                decode("a=1&a=2&b[]=1&b[]=2", DecodeOptions(duplicates = Duplicates.LAST)) shouldBe
+                    mapOf("a" to "2", "b" to listOf("1", "2"))
             }
         }
 
@@ -1167,11 +1236,20 @@ class DecodeSpec :
                     mapOf("a" to mapOf("0" to "1", "1" to "2"))
             }
 
-            it("handles negative list limit correctly") {
+            it("handles negative list limit without throwing") {
                 decode(
                     "a[]=1&a[]=2",
-                    DecodeOptions(listLimit = -1, throwOnLimitExceeded = true),
-                ) shouldBe mapOf("a" to listOf("1", "2"))
+                    DecodeOptions(listLimit = -1, throwOnLimitExceeded = false),
+                ) shouldBe mapOf("a" to mapOf("0" to "1", "1" to "2"))
+            }
+
+            it("throws on negative list limit when throwOnLimitExceeded=true") {
+                shouldThrow<IndexOutOfBoundsException> {
+                    decode(
+                        "a[]=1&a[]=2",
+                        DecodeOptions(listLimit = -1, throwOnLimitExceeded = true),
+                    )
+                }
             }
 
             it("applies list limit to nested lists") {
@@ -1267,9 +1345,9 @@ class DecodeSpec :
                     mapOf("a" to mapOf("b" to ""))
             }
 
-            it("depth=0 with allowDots=true: do not split key") {
+            it("depth=0 with allowDots=true: normalizes dots but does not split key") {
                 decode("a.b=c", DecodeOptions(allowDots = true, depth = 0)) shouldBe
-                    mapOf("a.b" to "c")
+                    mapOf("a[b]" to "c")
             }
 
             it("top-level dot→bracket conversion guardrails: leading/trailing/double dots") {
@@ -1551,7 +1629,7 @@ class DecodeSpec :
                 }
             }
 
-            it("depth=0: never split; return the original key as a single segment") {
+            it("depth=0: normalize dots and return one key segment") {
                 val segs1 =
                     InternalDecoder.splitKeyIntoSegments(
                         originalKey = "a.b.c",
@@ -1559,7 +1637,7 @@ class DecodeSpec :
                         maxDepth = 0,
                         strictDepth = false,
                     )
-                segs1 shouldBe listOf("a.b.c")
+                segs1 shouldBe listOf("a[b][c]")
 
                 val segs2 =
                     InternalDecoder.splitKeyIntoSegments(
@@ -1644,12 +1722,12 @@ class DecodeSpec :
                 }
 
                 it(
-                    "comma-separated values over listLimit are truncated when throwOnLimitExceeded=false"
+                    "comma-separated values over listLimit convert to a map when throwOnLimitExceeded=false"
                 ) {
                     decode(
                         "a=1,2,3,4",
                         DecodeOptions(comma = true, listLimit = 3, throwOnLimitExceeded = false),
-                    ) shouldBe mapOf("a" to listOf("1", "2", "3"))
+                    ) shouldBe mapOf("a" to mapOf("0" to "1", "1" to "2", "2" to "3", "3" to "4"))
                 }
 
                 it("advisory-shaped payload throws when comma split exceeds listLimit") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -431,7 +431,7 @@ class DecodeSpec :
                 decode("pets=[\"tobi\"]") shouldBe mapOf("pets" to "[\"tobi\"]")
                 decode("operators=[\">=\", \"<=\"]") shouldBe
                     mapOf("operators" to "[\">=\", \"<=\"]")
-                decode("a=foo[]=bar") shouldBe mapOf("a" to "foo[]=bar")
+                decode("a=foo[]=bar") shouldBe mapOf("a=foo" to listOf("bar"))
             }
 
             it("allows empty values") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/DecodeSpec.kt
@@ -431,6 +431,7 @@ class DecodeSpec :
                 decode("pets=[\"tobi\"]") shouldBe mapOf("pets" to "[\"tobi\"]")
                 decode("operators=[\">=\", \"<=\"]") shouldBe
                     mapOf("operators" to "[\">=\", \"<=\"]")
+                decode("a=foo[]=bar") shouldBe mapOf("a" to "foo[]=bar")
             }
 
             it("allows empty values") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/EncodeSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/EncodeSpec.kt
@@ -616,6 +616,45 @@ class EncodeSpec :
                 ) shouldBe "a%5B0%5D=%2C&a%5B1%5D=&a%5B2%5D=c%2Cd%25"
             }
 
+            it("does not crash on null entries in comma lists with encodeValuesOnly") {
+                encode(
+                    mapOf("a" to listOf(null, "b")),
+                    EncodeOptions(listFormat = ListFormat.COMMA, encodeValuesOnly = true),
+                ) shouldBe "a=,b"
+
+                encode(
+                    mapOf("a" to listOf(null, "b")),
+                    EncodeOptions(
+                        listFormat = ListFormat.COMMA,
+                        encodeValuesOnly = true,
+                        skipNulls = true,
+                    ),
+                ) shouldBe "a=,b"
+
+                encode(
+                    mapOf("a" to listOf<String?>(null)),
+                    EncodeOptions(listFormat = ListFormat.COMMA, encodeValuesOnly = true),
+                ) shouldBe "a="
+
+                encode(
+                    mapOf("a" to listOf<String?>(null)),
+                    EncodeOptions(
+                        listFormat = ListFormat.COMMA,
+                        encodeValuesOnly = true,
+                        strictNullHandling = true,
+                    ),
+                ) shouldBe "a"
+
+                encode(
+                    mapOf("a" to listOf<String?>(null)),
+                    EncodeOptions(
+                        listFormat = ListFormat.COMMA,
+                        encodeValuesOnly = true,
+                        skipNulls = true,
+                    ),
+                ) shouldBe ""
+            }
+
             it("encodes comma and empty non-list values") {
                 encode(
                     mapOf("a" to ",", "b" to "", "c" to "c,d%"),
@@ -1413,6 +1452,11 @@ class EncodeSpec :
 
                 encode(mapOf("foo(ref)" to "bar"), EncodeOptions(format = Format.RFC1738)) shouldBe
                     "foo(ref)=bar"
+
+                encode(
+                    mapOf("a b" to null, "c d" to "e f"),
+                    EncodeOptions(strictNullHandling = true, format = Format.RFC1738),
+                ) shouldBe "a+b&c+d=e+f"
             }
 
             it("RFC 3986 spaces serialization") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/QsParserSpec.kt
@@ -119,6 +119,9 @@ class QsParserSpec :
 
                 decode("a[0][0]=b&a[0][1]=c&a[1]=d&e=2", optionsDepth0) shouldBe
                     mapOf("a[0][0]" to "b", "a[0][1]" to "c", "a[1]" to "d", "e" to "2")
+
+                decode("a.b=c", DecodeOptions(depth = 0, allowDots = true)) shouldBe
+                    mapOf("a[b]" to "c")
             }
 
             it("should parse an explicit array") {
@@ -157,7 +160,7 @@ class QsParserSpec :
                     mapOf("a" to listOf("y", "x"))
 
                 decode(".a[b]=x&a=y", DecodeOptions(allowDots = true)) shouldBe
-                    mapOf("a" to mapOf("b" to "x", "y" to true))
+                    mapOf("a" to listOf(mapOf("b" to "x"), "y"))
 
                 decode("a[1]=b&a=c", options20) shouldBe mapOf("a" to listOf("b", "c"))
 
@@ -197,13 +200,13 @@ class QsParserSpec :
                 val options = DecodeOptions()
                 val options20 = DecodeOptions(listLimit = 20)
 
-                decode("a[20]=a", options20) shouldBe mapOf("a" to listOf("a"))
+                decode("a[19]=a", options20) shouldBe mapOf("a" to listOf("a"))
 
-                decode("a[21]=a", options20) shouldBe mapOf("a" to mapOf("21" to "a"))
+                decode("a[20]=a", options20) shouldBe mapOf("a" to mapOf("20" to "a"))
 
-                decode("a[20]=a", options) shouldBe mapOf("a" to listOf("a"))
+                decode("a[19]=a", options) shouldBe mapOf("a" to listOf("a"))
 
-                decode("a[21]=a", options) shouldBe mapOf("a" to mapOf("21" to "a"))
+                decode("a[20]=a", options) shouldBe mapOf("a" to mapOf("20" to "a"))
             }
 
             it("should support keys that begin with a number") {
@@ -604,7 +607,9 @@ class QsParserSpec :
             it("should add keys to objects") {
                 val options = DecodeOptions()
 
-                decode("a[b]=c&a=d", options) shouldBe mapOf("a" to mapOf("b" to "c", "d" to true))
+                decode("a[b]=c&a=d", options) shouldBe mapOf("a" to listOf(mapOf("b" to "c"), "d"))
+                decode("a[b]=c&a=d", DecodeOptions(strictMerge = false)) shouldBe
+                    mapOf("a" to mapOf("b" to "c", "d" to true))
             }
 
             it("should parse with custom encoding") {
@@ -1097,7 +1102,9 @@ class QsParserSpec :
                 Utils.merge(a, b) shouldBe mapOf("foo" to listOf("baz", "bar", "xyzz"))
 
                 val x = mapOf("foo" to "baz")
-                Utils.merge(x, "bar") shouldBe mapOf("foo" to "baz", "bar" to true)
+                Utils.merge(x, "bar") shouldBe listOf(mapOf("foo" to "baz"), "bar")
+                Utils.merge(x, "bar", DecodeOptions(strictMerge = false)) shouldBe
+                    mapOf("foo" to "baz", "bar" to true)
             }
         }
     })

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/UtilsSpec.kt
@@ -696,6 +696,19 @@ class UtilsSpec :
                 Utils.merge(mapOf("a" to "b"), "") shouldBe mapOf("a" to "b")
             }
 
+            test("strictMerge wraps map and scalar in a list by default") {
+                Utils.merge(mapOf("foo" to "bar"), "baz") shouldBe
+                    listOf(mapOf("foo" to "bar"), "baz")
+            }
+
+            test("strictMerge=false adds a scalar string as a map key") {
+                Utils.merge(
+                    mapOf("foo" to "bar"),
+                    "baz",
+                    DecodeOptions(strictMerge = false),
+                ) shouldBe mapOf("foo" to "bar", "baz" to true)
+            }
+
             test("merges two objects with the same key") {
                 val result = Utils.merge(mapOf("a" to "b"), mapOf("a" to "c"))
                 result shouldBe mapOf("a" to listOf("b", "c"))
@@ -924,10 +937,10 @@ class UtilsSpec :
                 map.maxIndex shouldBe 4
             }
 
-            test("combine does not overflow when listLimit is negative") {
+            test("combine overflows when listLimit is negative") {
                 val result = Utils.combine("a", "b", limit = -1)
-                result.shouldBeInstanceOf<List<*>>()
-                result shouldBe listOf("a", "b")
+                result.shouldBeInstanceOf<Utils.OverflowMap>()
+                result shouldBe mapOf("0" to "a", "1" to "b")
             }
 
             test("both lists") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/internal/DecoderInternalSpec.kt
@@ -21,6 +21,7 @@ private val parseListValueMethod by lazy {
             Any::class.java,
             DecodeOptions::class.java,
             Int::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType,
         )
         .apply { isAccessible = true }
 }
@@ -29,7 +30,9 @@ private fun invokeParseListValue(
     input: String,
     options: DecodeOptions,
     currentListLength: Int,
-): Any? = parseListValueMethod.invoke(Decoder, input, options, currentListLength)
+    isBracketListValue: Boolean = false,
+): Any? =
+    parseListValueMethod.invoke(Decoder, input, options, currentListLength, isBracketListValue)
 
 class DecoderInternalSpec :
     DescribeSpec({
@@ -140,13 +143,13 @@ class DecoderInternalSpec :
                 result["a"] shouldBe listOf("", "")
             }
 
-            it("comma parsing truncates when listLimit is exceeded and throw disabled") {
+            it("comma parsing converts to a map when listLimit is exceeded and throw disabled") {
                 val result =
                     Decoder.parseQueryStringValues(
                         "a=1,2,3",
                         DecodeOptions(comma = true, listLimit = 2, throwOnLimitExceeded = false),
                     )
-                result["a"] shouldBe listOf("1", "2")
+                result["a"] shouldBe mapOf("0" to "1", "1" to "2", "2" to "3")
             }
 
             it("comma parsing throws when listLimit is exceeded and throw enabled") {

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/models/DecodeOptionsSpec.kt
@@ -33,6 +33,7 @@ class DecodeOptionsSpec :
                         interpretNumericEntities = true,
                         parameterLimit = 200,
                         parseLists = true,
+                        strictMerge = false,
                         strictNullHandling = true,
                     )
 
@@ -51,6 +52,7 @@ class DecodeOptionsSpec :
                 newOptions.interpretNumericEntities shouldBe true
                 newOptions.parameterLimit shouldBe 200
                 newOptions.parseLists shouldBe true
+                newOptions.strictMerge shouldBe false
                 newOptions.strictNullHandling shouldBe true
                 newOptions shouldBe options
             }
@@ -71,6 +73,7 @@ class DecodeOptionsSpec :
                         interpretNumericEntities = true,
                         parameterLimit = 100,
                         parseLists = false,
+                        strictMerge = false,
                         strictNullHandling = true,
                     )
 
@@ -89,6 +92,7 @@ class DecodeOptionsSpec :
                         interpretNumericEntities = false,
                         parameterLimit = 200,
                         parseLists = true,
+                        strictMerge = true,
                         strictNullHandling = false,
                     )
 
@@ -105,6 +109,7 @@ class DecodeOptionsSpec :
                 newOptions.interpretNumericEntities shouldBe false
                 newOptions.parameterLimit shouldBe 200
                 newOptions.parseLists shouldBe true
+                newOptions.strictMerge shouldBe true
                 newOptions.strictNullHandling shouldBe false
             }
 
@@ -114,6 +119,38 @@ class DecodeOptionsSpec :
 
             it("exposes defaults() convenience instance") {
                 DecodeOptions.defaults() shouldBe DecodeOptions()
+            }
+
+            it("keeps strictNullHandling at its legacy positional constructor slot") {
+                val options =
+                    DecodeOptions(
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        20,
+                        StandardCharsets.UTF_8,
+                        false,
+                        false,
+                        Delimiter.AMPERSAND,
+                        5,
+                        1000,
+                        Duplicates.COMBINE,
+                        false,
+                        false,
+                        true,
+                        false,
+                        true,
+                        false,
+                    )
+
+                options.parseLists shouldBe true
+                options.strictDepth shouldBe false
+                options.strictNullHandling shouldBe true
+                options.throwOnLimitExceeded shouldBe false
+                options.strictMerge shouldBe true
             }
         }
 
@@ -320,6 +357,7 @@ class DecodeOptionsSpec :
                         .interpretNumericEntities(true)
                         .parseLists(false)
                         .strictDepth(true)
+                        .strictMerge(false)
                         .strictNullHandling(true)
                         .throwOnLimitExceeded(true)
                         .build()
@@ -342,6 +380,7 @@ class DecodeOptionsSpec :
                 options.interpretNumericEntities shouldBe true
                 options.parseLists shouldBe false
                 options.strictDepth shouldBe true
+                options.strictMerge shouldBe false
                 options.strictNullHandling shouldBe true
                 options.throwOnLimitExceeded shouldBe true
                 options.decode("token", StandardCharsets.ISO_8859_1, DecodeKind.KEY) shouldBe

--- a/skills/qs-kotlin/SKILL.md
+++ b/skills/qs-kotlin/SKILL.md
@@ -142,14 +142,17 @@ Use these options with `decode(query, DecodeOptions(...))` in Kotlin or
 - Double-encoded literal dots in keys such as `name%252Eobj.first=John`:
   `decodeDotInKeys = true`.
 - Duplicate keys: `duplicates = Duplicates.COMBINE` keeps all values as a list;
-  use `Duplicates.FIRST` or `Duplicates.LAST` to collapse.
+  use `Duplicates.FIRST` or `Duplicates.LAST` to collapse plain duplicate keys.
+  Bracket-list keys such as `items[]` always combine.
 - Bracket lists: enabled by default; set `parseLists = false` to treat list
   syntax as map keys.
 - Empty list tokens such as `foo[]`: `allowEmptyLists = true`.
-- Large or sparse list indices: default `listLimit` is `20`; indices above the
-  limit become map keys. A negative `listLimit` disables numeric-index list
-  parsing.
+- Large or sparse list indices: default `listLimit` is `20`; indices greater
+  than or equal to the limit become map keys. A negative `listLimit` forces list
+  values to map overflow, or throws when `throwOnLimitExceeded = true`.
 - Comma-separated values such as `a=b,c`: `comma = true`.
+- Object/scalar conflicts such as `a[b]=c&a=d`: `strictMerge = true` wraps the
+  conflict in a list; set `strictMerge = false` for legacy key-as-true behavior.
 - Tokens without `=` as `null`: `strictNullHandling = true`.
 - Custom delimiters: `delimiter = Delimiter.SEMICOLON`,
   `delimiter = StringDelimiter(";")`, or `delimiter = RegexDelimiter("[;,]")`.
@@ -277,7 +280,8 @@ Warn or adjust before giving code for these cases:
 - `parameterLimit` must be positive, or `Int.MAX_VALUE` for effectively
   unlimited parsing.
 - `throwOnLimitExceeded = true` turns parameter and list limit violations into
-  `IndexOutOfBoundsException`; without it, parsing truncates or falls back.
+  `IndexOutOfBoundsException`; without it, parameter parsing stops at the limit
+  and list overflows fall back to maps.
 - `strictDepth = true` throws on well-formed depth overflow; with the default
   `false`, the remainder beyond `depth` is kept as a trailing key segment.
 - Built-in charset handling supports only `StandardCharsets.UTF_8` and


### PR DESCRIPTION
This pull request introduces several important improvements and fixes to the query string decoding logic, aligning the behavior more closely with `qs` version 6.15.x and enhancing standards compliance. The main changes include the addition of a new `strictMerge` option, improved handling of object/scalar conflicts, and more accurate list and map overflow semantics. The documentation and tests have also been updated to reflect these changes.

**Decode options and merge semantics:**

* Added a new `DecodeOptions.strictMerge` option, which changes how object/scalar conflicts are resolved—by default, such conflicts now wrap both values in a list to match `qs` 6.15.0 behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R425-R465) [[3]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524R214-R223)
* Improved the merging logic to wrap object/scalar conflicts in a list when `strictMerge` is enabled, and updated the merge utility to treat falsy primitives as ignorable during merges. [[1]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524R41-R55) [[2]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L95-R110) [[3]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524R214-R223) [[4]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524R238-L214)

**List and map overflow handling:**

* Updated list limit semantics: explicit indices greater than or equal to `listLimit` now convert to a map, and comma-split overflows are preserved as maps instead of being truncated, matching `qs` 6.15.x. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L536-R589) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L604-R654) [[4]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L26-R50) [[5]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L333-R364) [[6]](diffhunk://#diff-c49f8bbed51599f635be26af5210e45c21af0b58b5c7b57574bf250a26a10524L872-R897) [[7]](diffhunk://#diff-def1216dfdc80439570562d96bd1d03878b8e3d71c5437dbfc0847f261d1de61L70-R74)
* Improved bracket-list and duplicate handling to always combine bracket-list values and match the latest `qs` behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R390-R395) [[3]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L255-R268)

**Standards compliance and edge case fixes:**

* Fixed depth-zero key normalization to match RFC behavior and applied formatters to strict-null encoded keys. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-6e3d9122490323b1d7b9b4f12cea0c940c212e3a01abd8226cf1c3181f4c8677L492-L500) [[3]](diffhunk://#diff-91e419bdf67b4f5efc478cc1f2cf64295054e1e30f0f5c10c01868d5bb300bbeL234-R234) [[4]](diffhunk://#diff-91e419bdf67b4f5efc478cc1f2cf64295054e1e30f0f5c10c01868d5bb300bbeL566-R566)

**Documentation and dependency updates:**

* Updated the `README.md` documentation to explain the new `strictMerge` option, improved examples for list/map overflow handling, and clarified bracket-list and duplicate semantics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R390-R395) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R425-R465) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L536-R589) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L557-R605) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L575-R623) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L604-R654)
* Updated the `qs` dependency in the JS comparison project from version 6.15.1 to 6.15.2 to ensure parity in behavior and test coverage. [[1]](diffhunk://#diff-d04983ff78523ea57aa368a4b081b88286aa8d5a168e4947d3fce1e6336febfeL9-R9) [[2]](diffhunk://#diff-c71ea775955f47befe2affa06e25604e0e89a2fc7024ec730745b98c1d661a11L12-R13) [[3]](diffhunk://#diff-c71ea775955f47befe2affa06e25604e0e89a2fc7024ec730745b98c1d661a11L72-R73) [[4]](diffhunk://#diff-c71ea775955f47befe2affa06e25604e0e89a2fc7024ec730745b98c1d661a11L150-R150)

These changes bring the decoding logic and documentation up to date with the latest `qs` standards, improve interoperability, and clarify the behavior for edge cases and advanced options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strictMerge option to control object/scalar conflict handling (wrap-by-default).

* **Bug Fixes**
  * Aligned decoding behavior with upstream 6.15.x: bracket-list duplicates combine, dot-notation normalized at depth=0, comma lists preserve overflow values and respect listLimit (convert over-limit indices to string-keyed maps), and strict-null key formatting follows RFC rules.
  * Improved merge handling for falsy primitives.

* **Documentation**
  * Updated examples and docs for duplicates, listLimit, comma behavior, and strictMerge.

* **Tests**
  * Expanded tests covering all above behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techouse/qs-kotlin/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->