### PR TITLE
:sparkles: add qs-kotlin-okhttp module for OkHttp integration with nested query parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run ktfmtCheck
-        run: ./gradlew :qs-kotlin:ktfmtCheck --stacktrace
+        run: ./gradlew :qs-kotlin:ktfmtCheck :qs-kotlin-okhttp:ktfmtCheck --stacktrace
       - name: Run spotlessCheck
         run: ./gradlew :qs-kotlin:spotlessCheck --stacktrace
   jvm_tests:
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Gradle (with caching)
         uses: gradle/actions/setup-gradle@v6
       - name: Run JVM tests
-        run: ./gradlew :qs-kotlin:clean :qs-kotlin:test :qs-kotlin:jacocoTestReport --stacktrace
+        run: ./gradlew :qs-kotlin:clean :qs-kotlin:test :qs-kotlin:jacocoTestReport :qs-kotlin-okhttp:clean :qs-kotlin-okhttp:test --stacktrace
       - name: Upload test results
         uses: codecov/codecov-action@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.0-dev
+
+* [FEAT] add optional `qs-kotlin-okhttp` JVM module with OkHttp `HttpUrl` and `HttpUrl.Builder` extensions for appending qs-kotlin encoded query parameters without double encoding
+* [CHORE] add OkHttp integration specification, README usage docs, publication metadata, CI coverage, and Kotest regression tests
+
 ## 1.5.9
 
 * [CHORE] update Kotlin to 2.4.0

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This repo provides:
 
 - **`qs-kotlin`** – the core JVM library (Jar)
 - **`qs-kotlin-android`** – a thin Android AAR wrapper that re-exports the same API
+- **`qs-kotlin-okhttp`** – optional OkHttp `HttpUrl` extensions for adding qs-style nested query parameters
 
-> If you only target the JVM (including Android projects that are fine with a plain Jar), just use `qs-kotlin`. The Android wrapper is provided for teams that prefer an AAR coordinate and AGP metadata.
+> If you only target the JVM (including Android projects that are fine with a plain Jar), just use `qs-kotlin`. The Android wrapper is provided for teams that prefer an AAR coordinate and AGP metadata. The OkHttp module is optional and keeps OkHttp out of the core artifact.
 
 ---
 
@@ -72,6 +73,21 @@ dependencies {
 }
 ```
 
+### OkHttp integration (Jar)
+
+Kotlin:
+```kotlin
+dependencies {
+    implementation("io.github.techouse:qs-kotlin-okhttp:<version>")
+}
+```
+Java (Gradle Groovy DSL):
+```groovy
+dependencies {
+    implementation 'io.github.techouse:qs-kotlin-okhttp:<version>'
+}
+```
+
 > The Android AAR depends on Java 17 APIs. If your app’s `minSdk < 26` and you use `java.time` transitively, enable **core library desugaring** in your app:
 
 Kotlin:
@@ -108,6 +124,7 @@ dependencies {
 - Kotlin **2.3.0+**
 - Java **17+**
 - Android wrapper: AGP **8.7+**, `compileSdk 35`, `minSdk 25`
+- OkHttp integration: OkHttp **5.4.0**
 
 ---
 
@@ -137,6 +154,82 @@ Map<@NotNull String, @Nullable Object> obj = QS.decode("foo[bar]=baz&foo[list][]
 String qs = QS.encode(Map.of("foo", Map.of("bar", "baz")));
 // -> "foo%5Bbar%5D=baz"
 ```
+
+---
+
+## OkHttp integration
+
+OkHttp's `HttpUrl.Builder.addQueryParameter` encodes names and values itself.
+qs-kotlin already returns an encoded query string, including nested bracket
+notation such as `filter%5Bwhere%5D%5Bname%5D=John`. The
+`qs-kotlin-okhttp` module splits qs-kotlin output into pairs and adds them with
+OkHttp's encoded query-parameter API to avoid double-encoding `%5B` into
+`%255B`.
+
+### HttpUrl.Builder
+
+```kotlin
+import io.github.techouse.qskotlin.okhttp.addQsQueryParameters
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+val url =
+    "https://api.example.com/products"
+        .toHttpUrl()
+        .newBuilder()
+        .addQsQueryParameters(
+            mapOf(
+                "filter" to
+                    mapOf(
+                        "where" to
+                            mapOf(
+                                "name" to "John",
+                                "age" to mapOf("gte" to 30),
+                            )
+                    ),
+                "tags" to listOf("a", "b"),
+            )
+        )
+        .build()
+
+// https://api.example.com/products?filter%5Bwhere%5D%5Bname%5D=John&filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30&tags%5B0%5D=a&tags%5B1%5D=b
+```
+
+### Immutable HttpUrl
+
+```kotlin
+import io.github.techouse.qskotlin.okhttp.addQsQueryParameters
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+val original = "https://api.example.com/products?existing=1".toHttpUrl()
+val updated = original.addQsQueryParameters(mapOf("page" to 2))
+
+// original: https://api.example.com/products?existing=1
+// updated:  https://api.example.com/products?existing=1&page=2
+```
+
+### List formats
+
+The integration uses qs-kotlin defaults unless you pass `EncodeOptions`.
+
+```kotlin
+import io.github.techouse.qskotlin.enums.ListFormat
+import io.github.techouse.qskotlin.models.EncodeOptions
+import io.github.techouse.qskotlin.okhttp.addQsQueryParameters
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+val repeated =
+    "https://api.example.com/search"
+        .toHttpUrl()
+        .addQsQueryParameters(
+            mapOf("tag" to listOf("kotlin", "android")),
+            EncodeOptions(listFormat = ListFormat.REPEAT),
+        )
+
+// https://api.example.com/search?tag=kotlin&tag=android
+```
+
+This module only targets `HttpUrl` and `HttpUrl.Builder`. Retrofit helpers are
+not included yet.
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ desugarJdkLibs = "2.1.5"
 androidCompileSdk = "36"
 androidMinSdk = "25"
 kotlinxSerializationJson = "1.11.0"
+okhttp = "5.4.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -30,3 +31,4 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 android-desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/qs-kotlin-okhttp/build.gradle.kts
+++ b/qs-kotlin-okhttp/build.gradle.kts
@@ -1,0 +1,104 @@
+import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktfmt)
+    `maven-publish`
+    signing
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.withType<Jar>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
+tasks.withType<KotlinCompile>().configureEach { compilerOptions.jvmTarget.set(JvmTarget.JVM_17) }
+
+dependencies {
+    api(project(":qs-kotlin"))
+    api(libs.okhttp)
+
+    testImplementation(platform(libs.kotest.bom))
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+}
+
+tasks.test { useJUnitPlatform() }
+
+ktfmt { kotlinLangStyle() }
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            pom {
+                name.set("qs-kotlin-okhttp")
+                description.set(
+                    "OkHttp HttpUrl integration for qs-kotlin nested query string encoding."
+                )
+                url.set("https://techouse.github.io/qs-kotlin/")
+                inceptionYear.set("2025")
+                licenses {
+                    license {
+                        name.set("BSD-3-Clause")
+                        url.set("https://github.com/techouse/qs-kotlin/blob/main/LICENSE")
+                        distribution.set("repo")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/techouse/qs-kotlin.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/techouse/qs-kotlin.git")
+                    url.set("https://github.com/techouse/qs-kotlin")
+                    tag.set("HEAD")
+                }
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("https://github.com/techouse/qs-kotlin/issues")
+                }
+                ciManagement {
+                    system.set("GitHub Actions")
+                    url.set("https://github.com/techouse/qs-kotlin/actions")
+                }
+                developers {
+                    developer {
+                        id.set("techouse")
+                        name.set("Klemen Tusar")
+                        email.set("techouse@gmail.com")
+                        url.set("https://github.com/techouse")
+                        roles.set(listOf("Lead", "Maintainer"))
+                        timezone.set("Europe/London")
+                        properties.put("twitter", "https://x.com/nextk2")
+                        properties.put("linkedin", "https://www.linkedin.com/in/techouse/")
+                        properties.put("sponsor", "https://github.com/sponsors/techouse")
+                        properties.put("paypal", "https://paypal.me/ktusar")
+                    }
+                }
+                properties.put(
+                    "changelogUrl",
+                    "https://github.com/techouse/qs_codec/blob/master/CHANGELOG.md",
+                )
+            }
+        }
+    }
+}
+
+signing {
+    val hasKey = providers.gradleProperty("signingInMemoryKey").isPresent
+    isRequired = hasKey && !project.version.toString().endsWith("SNAPSHOT")
+    if (hasKey) {
+        useInMemoryPgpKeys(
+            providers.gradleProperty("signingInMemoryKey").get(),
+            providers.gradleProperty("signingInMemoryKeyPassword").getOrElse(""),
+        )
+        sign(publishing.publications)
+    }
+}

--- a/qs-kotlin-okhttp/build.gradle.kts
+++ b/qs-kotlin-okhttp/build.gradle.kts
@@ -84,7 +84,7 @@ publishing {
                 }
                 properties.put(
                     "changelogUrl",
-                    "https://github.com/techouse/qs_codec/blob/master/CHANGELOG.md",
+                    "https://github.com/techouse/qs-kotlin/blob/main/CHANGELOG.md",
                 )
             }
         }

--- a/qs-kotlin-okhttp/src/main/kotlin/io/github/techouse/qskotlin/okhttp/HttpUrlExtensions.kt
+++ b/qs-kotlin-okhttp/src/main/kotlin/io/github/techouse/qskotlin/okhttp/HttpUrlExtensions.kt
@@ -1,0 +1,50 @@
+package io.github.techouse.qskotlin.okhttp
+
+import io.github.techouse.qskotlin.encode
+import io.github.techouse.qskotlin.models.EncodeOptions
+import okhttp3.HttpUrl
+
+/**
+ * Adds qs-kotlin encoded query parameters to this OkHttp URL builder.
+ *
+ * qs-kotlin already percent-encodes generated names and values, so this uses OkHttp's encoded
+ * query-parameter API to avoid double-encoding bracket notation and percent escapes.
+ */
+@JvmOverloads
+fun HttpUrl.Builder.addQsQueryParameters(
+    value: Any?,
+    options: EncodeOptions = EncodeOptions(),
+): HttpUrl.Builder {
+    if (value == null) return this
+
+    val query: String = encode(value, options)
+    if (query.isEmpty()) return this
+
+    val queryWithoutPrefix: String = if (options.addQueryPrefix) query.removePrefix("?") else query
+    if (queryWithoutPrefix.isEmpty()) return this
+
+    for (pair: String in options.delimiter.split(queryWithoutPrefix)) {
+        if (pair.isEmpty()) continue
+
+        val separatorIndex: Int = pair.indexOf('=')
+        if (separatorIndex < 0) {
+            addEncodedQueryParameter(pair, null)
+        } else {
+            addEncodedQueryParameter(
+                pair.substring(0, separatorIndex),
+                pair.substring(separatorIndex + 1),
+            )
+        }
+    }
+
+    return this
+}
+
+/**
+ * Returns a new URL with qs-kotlin encoded query parameters appended.
+ *
+ * The original immutable [HttpUrl] is left unchanged.
+ */
+@JvmOverloads
+fun HttpUrl.addQsQueryParameters(value: Any?, options: EncodeOptions = EncodeOptions()): HttpUrl =
+    newBuilder().addQsQueryParameters(value, options).build()

--- a/qs-kotlin-okhttp/src/test/kotlin/io/github/techouse/qskotlin/okhttp/HttpUrlExtensionsSpec.kt
+++ b/qs-kotlin-okhttp/src/test/kotlin/io/github/techouse/qskotlin/okhttp/HttpUrlExtensionsSpec.kt
@@ -1,0 +1,206 @@
+package io.github.techouse.qskotlin.okhttp
+
+import io.github.techouse.qskotlin.enums.ListFormat
+import io.github.techouse.qskotlin.models.Delimiter
+import io.github.techouse.qskotlin.models.EncodeOptions
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+class HttpUrlExtensionsSpec :
+    FunSpec({
+        test("null value returns the same builder unchanged") {
+            val original = "https://api.example.com/products".toHttpUrl()
+            val builder = original.newBuilder()
+
+            val result = builder.addQsQueryParameters(null)
+
+            result shouldBeSameInstanceAs builder
+            result.build() shouldBe original
+        }
+
+        test("empty encode result returns the same builder unchanged") {
+            val original = "https://api.example.com/products".toHttpUrl()
+            val builder = original.newBuilder()
+
+            val result = builder.addQsQueryParameters(emptyMap<String, Any?>())
+
+            result shouldBeSameInstanceAs builder
+            result.build() shouldBe original
+        }
+
+        test("simple map serializes into query parameters") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("q" to "kotlin", "page" to 2))
+                    .build()
+
+            url.toString() shouldBe "https://api.example.com/products?q=kotlin&page=2"
+            url.queryParameter("q") shouldBe "kotlin"
+            url.queryParameter("page") shouldBe "2"
+        }
+
+        test("nested map serializes into qs-style bracket notation") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(
+                        mapOf(
+                            "filter" to
+                                mapOf(
+                                    "where" to mapOf("name" to "John", "age" to mapOf("gte" to 30))
+                                )
+                        )
+                    )
+                    .build()
+
+            url.encodedQuery shouldBe
+                "filter%5Bwhere%5D%5Bname%5D=John&" + "filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30"
+        }
+
+        test("list serialization uses qs-kotlin default indices") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("tags" to listOf("a", "b")))
+                    .build()
+
+            url.encodedQuery shouldBe "tags%5B0%5D=a&tags%5B1%5D=b"
+        }
+
+        test("list of complex objects uses structured qs-style keys") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(
+                        mapOf(
+                            "items" to
+                                listOf(
+                                    mapOf("id" to 1, "name" to "first"),
+                                    mapOf("id" to 2, "name" to "second"),
+                                )
+                        )
+                    )
+                    .build()
+
+            url.encodedQuery shouldBe
+                "items%5B0%5D%5Bid%5D=1&items%5B0%5D%5Bname%5D=first&" +
+                    "items%5B1%5D%5Bid%5D=2&items%5B1%5D%5Bname%5D=second"
+        }
+
+        test("existing query parameters are preserved and qs parameters append") {
+            val url =
+                "https://api.example.com/products?existing=1"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("filter" to mapOf("name" to "John")))
+                    .build()
+
+            url.encodedQuery shouldBe "existing=1&filter%5Bname%5D=John"
+        }
+
+        test("duplicate keys are preserved") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(
+                        mapOf("tag" to listOf("a", "b")),
+                        EncodeOptions(listFormat = ListFormat.REPEAT),
+                    )
+                    .build()
+
+            url.encodedQuery shouldBe "tag=a&tag=b"
+            url.queryParameterValues("tag") shouldBe listOf("a", "b")
+        }
+
+        test("empty values are preserved") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("foo" to ""))
+                    .build()
+
+            url.encodedQuery shouldBe "foo="
+            url.queryParameter("foo") shouldBe ""
+        }
+
+        test("name-only values are preserved") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(
+                        mapOf("foo" to null),
+                        EncodeOptions(strictNullHandling = true),
+                    )
+                    .build()
+
+            url.encodedQuery shouldBe "foo"
+            url.queryParameterValue(0) shouldBe null
+        }
+
+        test("generated query prefix and custom delimiter are handled") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(
+                        mapOf("a" to "b", "c" to "d"),
+                        EncodeOptions(addQueryPrefix = true, delimiter = Delimiter.SEMICOLON),
+                    )
+                    .build()
+
+            url.encodedQuery shouldBe "a=b&c=d"
+        }
+
+        test("leading question mark in raw key is preserved when query prefix is disabled") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("?foo" to "bar"), EncodeOptions(encode = false))
+                    .build()
+
+            url.encodedQuery shouldBe "?foo=bar"
+            url.queryParameter("?foo") shouldBe "bar"
+        }
+
+        test("encoded qs output is not double-encoded") {
+            val url =
+                "https://api.example.com/products"
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQsQueryParameters(mapOf("a" to mapOf("b" to "c")))
+                    .build()
+
+            url.toString() shouldBe "https://api.example.com/products?a%5Bb%5D=c"
+            url.encodedQuery shouldBe "a%5Bb%5D=c"
+        }
+
+        test("builder extension returns the same builder instance") {
+            val builder = "https://api.example.com/products".toHttpUrl().newBuilder()
+
+            val result = builder.addQsQueryParameters(mapOf("a" to "b"))
+
+            result shouldBeSameInstanceAs builder
+        }
+
+        test("HttpUrl extension returns a new URL and leaves the original unchanged") {
+            val original = "https://api.example.com/products?existing=1".toHttpUrl()
+
+            val updated = original.addQsQueryParameters(mapOf("a" to "b"))
+
+            updated shouldNotBeSameInstanceAs original
+            original.toString() shouldBe "https://api.example.com/products?existing=1"
+            updated.toString() shouldBe "https://api.example.com/products?existing=1&a=b"
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,4 +33,4 @@ develocity {
 
 rootProject.name = "qs-kotlin"
 
-include(":qs-kotlin", ":qs-kotlin-android", ":comparison")
+include(":qs-kotlin", ":qs-kotlin-android", ":qs-kotlin-okhttp", ":comparison")


### PR DESCRIPTION
This pull request introduces a new `qs-kotlin-okhttp` module that provides OkHttp integration for qs-kotlin, allowing easy addition of nested query parameters to OkHttp URLs. It also updates documentation, build configuration, and CI workflows to support and test the new module.

**New OkHttp integration module:**

* Added the `qs-kotlin-okhttp` module, which provides extension functions for `HttpUrl` and `HttpUrl.Builder` to add qs-kotlin encoded query parameters without double-encoding. Includes Gradle setup, publishing, and signing configuration. [[1]](diffhunk://#diff-b776746fbc6235fe48fc94e1e90135e8b37b68e0376dce242e329e48a1c2b414R1-R104) [[2]](diffhunk://#diff-fcf684783d1e9a8c5ae9098355f58d6652685b02477de1dd2bc99f3f94baa812R1-R50) [[3]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dL36-R36)
* Added comprehensive tests for the new OkHttp extensions to ensure correct encoding, handling of nested structures, and preservation of existing query parameters.

**Documentation updates:**

* Updated `README.md` to document the new `qs-kotlin-okhttp` module, including usage examples, Gradle dependency instructions, and compatibility notes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76-R90) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160-R235)

**Build and CI improvements:**

* Updated dependency management to include OkHttp in `gradle/libs.versions.toml`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR16) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR34)
* Updated CI workflow in `.github/workflows/test.yml` to run formatting and tests for the new `qs-kotlin-okhttp` module. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L36-R36) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L63-R63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional OkHttp integration module for JVM applications to encode and append qs-kotlin query parameters to OkHttp `HttpUrl`/`HttpUrl.Builder`.

* **Documentation**
  * Updated README with OkHttp module installation instructions, requirements (OkHttp 5.4.0), and detailed usage examples.

* **Bug Fixes**
  * Improved CI test coverage by expanding Gradle test/cleanup execution to include the OkHttp module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->