### PR TITLE
:sparkles: add `java.net.URI.decodeQsQuery` extension for parsing raw URI query components and update documentation

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,11 @@
+---
+# Exclude test sources from Codacy code-pattern analysis.
+# Coverage exclusions must be handled in the coverage tool/report itself.
+exclude_paths:
+  - ".github/**"
+  - "comparison/**"
+  - "gradle/**"
+  - "qs-kotlin/src/test/**"
+  - "qs-kotlin-ktor/src/test/**"
+  - "qs-kotlin-okhttp/src/test/**"
+  - "qs-kotlin-spring-web/src/test/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.1
+
+* [FEAT] add core `java.net.URI.decodeQsQuery` extension for parsing raw URI query components without lossy pre-decoding
+* [CHORE] add URI decoding documentation, Kotlin and Java regression coverage, and qs-kotlin skill guidance
+
 ## 1.6.0
 
 * [FEAT] add optional `qs-kotlin-spring-web` JVM module with Spring Web `UriComponentsBuilder.queryQs` for appending qs-kotlin encoded query parameters

--- a/README.md
+++ b/README.md
@@ -462,6 +462,53 @@ String encoded = QS.encode(Map.of("a", "c"));
 
 ## Decoding
 
+### `java.net.URI`
+
+Use `decodeQsQuery` to decode a URI's raw query component without losing qs
+semantics:
+
+Kotlin:
+```kotlin
+import io.github.techouse.qskotlin.decodeQsQuery
+import java.net.URI
+
+val uri = URI("https://example.com/search?filter%5Bname%5D=Jane%20Doe")
+val decoded = uri.decodeQsQuery()
+// => mapOf("filter" to mapOf("name" to "Jane Doe"))
+```
+
+Java:
+```java
+import io.github.techouse.qskotlin.QS;
+import java.net.URI;
+import java.util.Map;
+
+URI uri = URI.create("https://example.com/search?filter%5Bname%5D=Jane%20Doe");
+Map<String, Object> decoded = QS.decodeQsQuery(uri);
+// => {filter={name=Jane Doe}}
+```
+
+The helper intentionally reads `URI.rawQuery`, not `URI.query`. The decoded
+accessor can turn an encoded value delimiter such as `%26` into `&` before qs
+parses the query, changing its structure. URIs with an absent or explicitly
+empty query return an empty map. Opaque URIs also return an empty map because
+Java does not expose a query component for them.
+
+To construct a new URI when there is no existing query to preserve, encode the
+query first and use the single-string URI constructor:
+
+```kotlin
+import io.github.techouse.qskotlin.toQueryString
+import java.net.URI
+
+val encoded = mapOf("filter" to mapOf("name" to "Jane Doe")).toQueryString()
+val uri = URI("https://example.com/search?$encoded")
+```
+
+Do not decode and re-encode an existing URI query to replace or append values;
+that can lose name-only values, duplicate ordering, delimiters, and list
+formatting.
+
 ### Nested maps
 
 Kotlin:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=io.github.techouse
-version=1.6.0
+version=1.6.1
 kotlin.code.style=official

--- a/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/extensions.kt
+++ b/qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/extensions.kt
@@ -5,6 +5,7 @@ package io.github.techouse.qskotlin
 
 import io.github.techouse.qskotlin.models.DecodeOptions
 import io.github.techouse.qskotlin.models.EncodeOptions
+import java.net.URI
 
 /**
  * Decode a query [String] into a [Map<String, Any?>].
@@ -23,3 +24,17 @@ fun String.toQueryMap(options: DecodeOptions? = null): Map<String, Any?> = decod
  */
 @JvmOverloads
 fun Map<*, *>.toQueryString(options: EncodeOptions? = null): String = encode(this, options)
+
+/**
+ * Decode this [URI]'s raw query component into a [Map<String, Any?>].
+ *
+ * This intentionally uses [URI.getRawQuery] instead of [URI.getQuery] so qs receives the original
+ * percent escapes. An absent or explicitly empty query, and an opaque URI without a query
+ * component, returns an empty Map.
+ *
+ * @param options [DecodeOptions] optional decoder settings
+ * @return [Map<String, Any?>] the decoded Map
+ */
+@JvmOverloads
+fun URI.decodeQsQuery(options: DecodeOptions? = null): Map<String, Any?> =
+    rawQuery?.toQueryMap(options) ?: emptyMap()

--- a/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/ExtensionsInteropTest.java
+++ b/qs-kotlin/src/test/java/io/github/techouse/qskotlin/interop/ExtensionsInteropTest.java
@@ -5,7 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.github.techouse.qskotlin.QS;
 import io.github.techouse.qskotlin.enums.ListFormat;
+import io.github.techouse.qskotlin.models.DecodeOptions;
 import io.github.techouse.qskotlin.models.EncodeOptions;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -42,5 +46,40 @@ final class ExtensionsInteropTest {
   @Test
   void map_toQueryString_uses_default_overload() {
     assertEquals("a=b", QS.toQueryString(Map.of("a", "b")));
+  }
+
+  @Test
+  void uri_decodeQsQuery_uses_raw_query() {
+    URI uri =
+        URI.create(
+            "https://example.com/search?filter%5Bname%5D=John%20Doe&tag=a&tag=b&escaped=x%26y&pct=%2525#results");
+
+    assertEquals(
+        Map.of(
+            "filter",
+            Map.of("name", "John Doe"),
+            "tag",
+            List.of("a", "b"),
+            "escaped",
+            "x&y",
+            "pct",
+            "%25"),
+        QS.decodeQsQuery(uri));
+  }
+
+  @Test
+  void uri_decodeQsQuery_accepts_options() {
+    DecodeOptions options =
+        DecodeOptions.builder().comma(true).delimiter(";").strictNullHandling(true).build();
+    Map<String, Object> expected = new LinkedHashMap<>();
+    expected.put("flag", null);
+    expected.put("tags", List.of("kotlin", "java"));
+
+    assertEquals(expected, QS.decodeQsQuery(URI.create("search?flag;tags=kotlin,java"), options));
+  }
+
+  @SuppressWarnings("unused")
+  private static Map<String, Object> string_toQueryMap_null_literal_stays_unambiguous() {
+    return QS.toQueryMap(null);
   }
 }

--- a/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExtensionsSpec.kt
+++ b/qs-kotlin/src/test/kotlin/io/github/techouse/qskotlin/unit/ExtensionsSpec.kt
@@ -1,11 +1,15 @@
 package io.github.techouse.qskotlin.unit
 
+import io.github.techouse.qskotlin.decodeQsQuery
 import io.github.techouse.qskotlin.fixtures.data.EndToEndTestCases
+import io.github.techouse.qskotlin.models.DecodeOptions
+import io.github.techouse.qskotlin.models.Delimiter
 import io.github.techouse.qskotlin.models.EncodeOptions
 import io.github.techouse.qskotlin.toQueryMap
 import io.github.techouse.qskotlin.toQueryString
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.net.URI
 
 class ExtensionsSpec :
     FunSpec({
@@ -27,6 +31,58 @@ class ExtensionsSpec :
 
             test("uses default EncodeOptions overload when omitted") {
                 mapOf("a" to "b").toQueryString() shouldBe "a=b"
+            }
+        }
+
+        context("URI.decodeQsQuery") {
+            test("decodes the raw query without losing qs semantics") {
+                val uri =
+                    URI(
+                        "https://example.com/search?" +
+                            "filter%5Bwhere%5D%5Bname%5D=John%20Doe&" +
+                            "tag=a&tag=b&flag&empty=&escaped=x%26y&pct=%2525&" +
+                            "plus=a+b&space=a%20b#results"
+                    )
+
+                uri.decodeQsQuery() shouldBe
+                    mapOf(
+                        "filter" to mapOf("where" to mapOf("name" to "John Doe")),
+                        "tag" to listOf("a", "b"),
+                        "flag" to "",
+                        "empty" to "",
+                        "escaped" to "x&y",
+                        "pct" to "%25",
+                        "plus" to "a b",
+                        "space" to "a b",
+                    )
+            }
+
+            test("forwards decoder options") {
+                val uri = URI("search?flag;tags=kotlin,android")
+
+                uri.decodeQsQuery(
+                    DecodeOptions(
+                        comma = true,
+                        delimiter = Delimiter.SEMICOLON,
+                        strictNullHandling = true,
+                    )
+                ) shouldBe mapOf("flag" to null, "tags" to listOf("kotlin", "android"))
+            }
+
+            test("decodes relative hierarchical URIs") {
+                URI("search?filter%5Bname%5D=Jane").decodeQsQuery() shouldBe
+                    mapOf("filter" to mapOf("name" to "Jane"))
+            }
+
+            test("returns an empty map for absent, empty, and opaque query components") {
+                val absentQuery = URI("https://example.com/path")
+                val emptyQuery = URI("https://example.com/path?")
+
+                absentQuery.rawQuery shouldBe null
+                emptyQuery.rawQuery shouldBe ""
+                absentQuery.decodeQsQuery() shouldBe emptyMap()
+                emptyQuery.decodeQsQuery() shouldBe emptyMap()
+                URI("mailto:user@example.com?subject=hello").decodeQsQuery() shouldBe emptyMap()
             }
         }
     })

--- a/skills/qs-kotlin/SKILL.md
+++ b/skills/qs-kotlin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qs-kotlin
-description: Use this skill whenever a user wants to install, configure, troubleshoot, or write Kotlin, Java, JVM, Android, OkHttp, Ktor, or Spring Web application code for encoding and decoding nested query strings with the qs-kotlin packages. This skill helps produce practical QS.decode, QS.encode, decode, encode, toQueryMap, toQueryString, addQsQueryParameters, appendQsQueryParameters, parseQsQuery, and queryQs snippets, choose DecodeOptions and EncodeOptions, explain option tradeoffs, and avoid qs-kotlin edge-case pitfalls around lists, dot notation, duplicates, null handling, charset sentinels, depth limits, Java interop, Android coordinates, framework URL builders, double encoding, and untrusted input.
+description: Use this skill whenever a user wants to install, configure, troubleshoot, or write Kotlin, Java, JVM, Android, OkHttp, Ktor, or Spring Web application code for encoding and decoding nested query strings with the qs-kotlin packages. This skill helps produce practical QS.decode, QS.encode, decode, encode, toQueryMap, toQueryString, decodeQsQuery, addQsQueryParameters, appendQsQueryParameters, parseQsQuery, and queryQs snippets, choose DecodeOptions and EncodeOptions, explain option tradeoffs, and avoid qs-kotlin edge-case pitfalls around lists, dot notation, duplicates, null handling, charset sentinels, depth limits, Java interop, java.net.URI raw query handling, Android coordinates, framework URL builders, double encoding, and untrusted input.
 ---
 
 # qs-kotlin Usage Assistant
@@ -16,7 +16,7 @@ maintenance.
 Before producing a final snippet, collect only the missing details that change
 the code:
 
-- Runtime: Kotlin/JVM, Android, Java, OkHttp, Ktor, Spring Web, tests,
+- Runtime: Kotlin/JVM, Android, Java, `java.net.URI`, OkHttp, Ktor, Spring Web, tests,
   backend code, or generated example.
 - Direction: decode an incoming query string, encode Kotlin or Java data, or
   normalize query-string handling around an existing URL/request object.
@@ -109,6 +109,19 @@ val params = "a[b]=c".toQueryMap()
 val query = mapOf("a" to mapOf("b" to "c")).toQueryString()
 ```
 
+Decode a `java.net.URI` through its raw query component:
+
+```kotlin
+import io.github.techouse.qskotlin.decodeQsQuery
+import java.net.URI
+
+val params = URI("https://example.com/?a%5Bb%5D=c").decodeQsQuery()
+```
+
+Use `QS.decodeQsQuery(uri)` from Java. This helper deliberately reads
+`URI.rawQuery`; do not pass `URI.query` or `URI.getQuery()` to qs because those
+accessors percent-decode before qs splits query pairs.
+
 Optional framework helpers live in integration packages:
 
 ```kotlin
@@ -176,6 +189,8 @@ Use these options with `decode(query, DecodeOptions(...))` in Kotlin or
 `QS.decode(query, DecodeOptions.builder()...build())` in Java:
 
 - Leading question mark: `ignoreQueryPrefix = true`.
+- `java.net.URI`: use `uri.decodeQsQuery(options)`, which reads `rawQuery` and
+  returns an empty map for absent, empty, or opaque query components.
 - Dot notation such as `a.b=c`: `allowDots = true`.
 - Double-encoded literal dots in keys such as `name%252Eobj.first=John`:
   `decodeDotInKeys = true`.
@@ -415,6 +430,9 @@ Warn or adjust before giving code for these cases:
 - The JDK and many web frameworks flatten duplicates or nested query syntax.
   Prefer `decode` or `QS.decode` on the raw query string when qs-style nested or
   repeated values matter.
+- For `java.net.URI`, prefer `decodeQsQuery`; never decode `URI.query` and then
+  pass it to qs, because encoded delimiters and percent signs can be decoded too
+  early.
 - OkHttp and Ktor URL helpers preserve qs-kotlin output by using encoded query
   parameter APIs; normal decoded query APIs can double-encode bracket notation.
 - Ktor server code should parse `ApplicationRequest.queryString()`, not
@@ -430,7 +448,7 @@ For code-generation requests, answer with:
    list format, null handling, charset, prefix handling, and whether input is
    trusted.
 2. One concrete Kotlin or Java snippet using `decode`, `encode`, `toQueryMap`,
-   `toQueryString`, `QS`, or the relevant framework helper.
+   `toQueryString`, `decodeQsQuery`, `QS`, or the relevant framework helper.
 3. A brief explanation of only the options used.
 4. A small verification example, such as an expected map, expected query string,
    JUnit assertion, Kotest assertion, or `check(...)`.


### PR DESCRIPTION
This pull request introduces a new extension function to decode the raw query component of a `java.net.URI` without lossy pre-decoding, updates documentation and skill guidance, and adds comprehensive regression tests for both Kotlin and Java. The main focus is on providing a reliable way to parse URI query strings while preserving qs-kotlin semantics, and ensuring users are guided to use this approach correctly.

**Core Feature:**

* Added `decodeQsQuery` extension for `java.net.URI` in `extensions.kt`, enabling direct decoding of the raw query component to a `Map<String, Any?>` without lossy pre-decoding. Returns an empty map for absent, empty, or opaque queries. ([[qs-kotlin/src/main/kotlin/io/github/techouse/qskotlin/extensions.ktR27-R40](diffhunk://#diff-d6d5f752315fa9a2172bcda136bbcc77874b0797fccf489cb4774a6f090b8df1R27-R40)])

**Documentation & Guidance:**

* Updated `README.md` with usage examples and explanation of the new `decodeQsQuery` helper for both Kotlin and Java, highlighting its correct usage and caveats. ([[README.mdR465-R511](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R465-R511)])
* Expanded `skills/qs-kotlin/SKILL.md` to include `decodeQsQuery` in the description, usage instructions, option recommendations, and code-generation guidance. Emphasized the importance of using `rawQuery` and not `query` for qs-style decoding. [[1]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL3-R3)], [[2]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL19-R19)], [[3]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR112-R124)], [[4]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR192-R193)], [[5]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR433-R435)], [[6]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL433-R451)])

**Testing & Regression:**

* Added comprehensive Kotlin (`ExtensionsSpec.kt`) and Java (`ExtensionsInteropTest.java`) tests covering normal, edge, and option-forwarding cases for `decodeQsQuery`, including absent, empty, and opaque queries. [[1]](diffhunk://#diff-dc5149df173eb546bb2530b96830d3a10b8e8866173675e10a8692a331f75a5cR36-R87)], [[2]](diffhunk://#diff-82081a47c3fdd852d926c7156d3e9271b4b2fe78385fd5211a23bda100f9be37R50-R84)])

**Changelog & Versioning:**

* Bumped version to `1.6.1` and updated `CHANGELOG.md` to reflect the new feature, documentation, and test coverage. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5)], [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L2-R2)])

**Skill Guidance:**

* Updated skill documentation to include `decodeQsQuery` in practical snippet recommendations and troubleshooting advice for `java.net.URI` handling. [[1]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL3-R3)], [[2]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL19-R19)], [[3]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR112-R124)], [[4]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR192-R193)], [[5]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eR433-R435)], [[6]](diffhunk://#diff-2018b6460e9e7e0151ffb53e733806268e722f04f290e7f6e15b87f8cd5f302eL433-R451)])

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes v1.6.1

* **New Features**
  * Added support for decoding URI raw query components in Kotlin.

* **Documentation**
  * Added comprehensive guide for decoding URI query strings, including examples and best practices.

* **Tests**
  * Added test coverage for URI query decoding with various options and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->